### PR TITLE
docs: refocus portfolio scope on nwalker health

### DIFF
--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -41,6 +41,6 @@
 
 `docs/domain-portfolio.md` is the current boundary map. It preserves the decision to keep personal, company, product, methodology, and personal-project properties separate while sharing implementation standards.
 
-## Cloudflare State
+## DNS State
 
-The available `Cloudflare Manage DNS` token can read existing zones and manage DNS for existing zones, but zone creation is blocked by missing account-level `zone.create` permission.
+`nwalker.cc` and `staging.nwalker.cc` use Cloudflare as part of this repo's current production architecture. Other domains are not in scope for Cloudflare migration from this repo.

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -35,11 +35,11 @@
 | `PRD.md` | Public portfolio and authority-corpus requirements |
 | `ARCHITECTURE.md` | Next.js, AWS, Cloudflare, and deployment architecture |
 | `CURRENT_STATE.md` | Live production/staging status and known repos |
-| `GAPS.md` | Risks around Cloudflare migration, docs, monitoring, and domain split |
+| `GAPS.md` | Risks around health, monitoring, positioning, docs, and domain-boundary drift |
 | `ROADMAP.md` | Phased site and domain portfolio plan |
 | `IMPLEMENTATION_PLAN.md` | Current execution checklist |
-| `RUNBOOK.md` | Tag, deploy, DNS, Cloudflare, and verification procedures |
-| `domain-portfolio.md` | Domain boundary and migration policy |
+| `RUNBOOK.md` | Tag, deploy, existing `nwalker.cc` DNS, and verification procedures |
+| `domain-portfolio.md` | Domain boundary policy |
 
 ## Naming Convention
 

--- a/docs/GAPS.md
+++ b/docs/GAPS.md
@@ -7,7 +7,7 @@
 | Owner | Nathan Walker |
 | Domain | Personal authority site |
 | Scope | Known missing pieces and risks |
-| Related Services | `nwalker.cc`, Cloudflare, GitHub Actions, AWS ECS |
+| Related Services | `nwalker.cc`, `staging.nwalker.cc`, GitHub Actions, AWS ECS, Cloudflare for existing `nwalker.cc` DNS |
 | Related ADRs | ADR-001 |
 | Review Cadence | Monthly |
 | Retention Rule | Retain until superseded by resolved implementation evidence |
@@ -16,19 +16,18 @@
 
 ## High Priority
 
-- Cloudflare automation cannot add zones until the token has account-level zone create/edit permission.
-- The domain portfolio needs separate repos/sites for Ravenhelm, Runestack, Domain Intelligence Schema, Artimetrics, and personal project surfaces.
-- Monitoring and alerting should cover production, staging, and priority external domains with notification evidence.
+- Monitoring and alerting must cover `nwalker.cc` and `staging.nwalker.cc` with notification evidence.
+- The homepage is close but not fully aligned to the final strategic refinement recommendations.
+- Primary navigation is still broader than the final executive structure.
 
 ## Medium Priority
 
-- Add richer examples and FAQ sections to AI authority pages.
-- Add backlinks and off-site mirrors for citable methodology content.
-- Add a repeatable Cloudflare migration runbook per domain.
+- Add richer examples and FAQ sections to AI authority pages when they support `nwalker.cc` credibility.
+- Add a concise health/runbook section for production verification.
+- Keep adjacent-domain plans out of the active `nwalker.cc` checklist unless explicitly reopened.
 - Normalize GitHub Actions action versions as ecosystem warnings emerge.
 
 ## Low Priority
 
-- Decide whether `hrafngrima.com` redirects or becomes a distinct personal property.
-- Verify ownership and renewal plan for `theviking.tools`.
-- Let `clutchtap.com` expire after dependency check if no strategic use remains.
+- Decide later whether adjacent personal domains need their own workstreams.
+- Let unrelated domain decisions stay outside this repo's active health checklist.

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -7,7 +7,7 @@
 | Owner | Nathan Walker |
 | Domain | Personal authority site |
 | Scope | Current implementation checklist |
-| Related Services | `nwalker.cc`, GitHub Actions, Cloudflare, Domain Intelligence Schema |
+| Related Services | `nwalker.cc`, `staging.nwalker.cc`, GitHub Actions, AWS ECS, Cloudflare for existing `nwalker.cc` DNS |
 | Related ADRs | ADR-001 |
 | Review Cadence | Weekly while active |
 | Retention Rule | Retain until superseded by the next active plan |
@@ -20,21 +20,19 @@
 - Verify `/ecosystem` and sitemap from the public internet.
 - Add controlled documentation structure to this repo.
 - Update GitHub Actions versions that trigger runtime deprecation warnings.
-- Clone and prepare the Domain Intelligence Schema repo as the first separate property workspace.
-- Add controlled docs and runbook coverage to the Domain Intelligence Schema repo.
+- Keep `nwalker.cc` focused on health, completeness, and strategic refinement.
+- Align homepage, navigation, architecture, enterprise, Runestack, and contact sections with the strategic refinement recommendations.
 
 ## Human-Owned Work
 
-- Update Cloudflare token permissions or create a new token with account-level zone create/edit access.
-- Change nameservers at Squarespace during each domain migration.
 - Approve production deployment gates.
-- Decide final positioning and legal footer language for company and product domains.
-- Decide whether `clutchtap.com` can expire after dependency review.
+- Approve any material positioning changes that alter executive-market narrative.
+- Decide whether off-site personal/domain properties need separate workstreams later.
 
 ## Next Checklist
 
-1. Finish `nwalker.cc` documentation and workflow PR.
-2. Finish `domainintelligenceschema.org` documentation PR.
-3. Create or update Cloudflare token and store it in 1Password.
-4. Migrate `domainintelligenceschema.org` to Cloudflare.
-5. Add monitors for `nwalker.cc`, `staging.nwalker.cc`, and `domainintelligenceschema.org`.
+1. Remove stale domain-wide Cloudflare migration language.
+2. Add health checks for `nwalker.cc` and `staging.nwalker.cc`.
+3. Implement the homepage refinement pass from the portfolio strategic recommendations.
+4. Simplify primary navigation to the final executive structure.
+5. Audit production after each deploy: root, key routes, sitemap, robots, canonical metadata, and contact path.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -7,7 +7,7 @@
 | Owner | Nathan Walker |
 | Domain | Personal authority site |
 | Scope | Portfolio and domain portfolio roadmap |
-| Related Services | `nwalker.cc`, `domainintelligenceschema.org`, Cloudflare |
+| Related Services | `nwalker.cc`, `staging.nwalker.cc`, GitHub Actions, AWS ECS, Cloudflare for existing `nwalker.cc` DNS |
 | Related ADRs | ADR-001 |
 | Review Cadence | Monthly |
 | Retention Rule | Retain for repository lifetime |
@@ -21,22 +21,21 @@
 - Fix GitHub Actions warnings as action releases become available.
 - Add smoke-test evidence to runbooks.
 
-## Phase 2: Launch Separate Methodology Properties
+## Phase 2: Refine Executive Positioning
 
-- Treat `domainintelligenceschema.org` as the first separate property.
-- Add controlled docs and operator runbooks to the DIS repo.
-- Cross-link DIS from `nwalker.cc`.
-- Prepare Artimetrics as the second methodology/concept property.
+- Align the homepage to the final strategic structure.
+- Simplify navigation to Philosophy, Enterprise, Architecture, Runestack, Portfolio, Contact.
+- Keep homepage copy restrained, memo-grade, and focused on executive systems stewardship.
+- Keep dense proof on the enterprise portfolio page.
 
-## Phase 3: Cloudflare Migration
+## Phase 3: Health And Monitoring
 
-- Update or create a Cloudflare token with zone create/edit and DNS edit permissions.
-- Add/migrate priority zones.
-- Preserve existing records before nameserver cutovers.
-- Configure redirects, robots policy, TLS, and uptime checks.
+- Add explicit health checks for production and staging.
+- Verify root, key pages, sitemap, robots, canonical URLs, security headers, and contact path after deploys.
+- Make outage notification evidence part of the operating record.
 
-## Phase 4: Business And Product Surfaces
+## Phase 4: Adjacent Properties
 
-- Build Ravenhelm company properties separately from personal identity.
-- Build Runestack product properties separately from Ravenhelm and personal identity.
-- Share documentation standards, deployment conventions, and observability expectations.
+- Leave `domainintelligenceschema.org` on its current healthy GitHub Pages setup.
+- Open separate workstreams for Ravenhelm, Runestack, Artimetrics, or other domains only when the user explicitly scopes them.
+- Share documentation standards where useful without imposing shared infrastructure.

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -60,23 +60,22 @@ curl -I https://nwalker.cc/ecosystem
 curl -s https://nwalker.cc/sitemap.xml | rg 'ecosystem|definitions|frameworks|patterns'
 ```
 
-## Cloudflare Token Check
+## Existing DNS Check
 
-Use a shell-scoped 1Password value. Do not export Cloudflare or 1Password tokens globally.
+Use this only for the existing `nwalker.cc` Cloudflare zone. Do not use this runbook as a domain-wide migration plan.
 
 ```bash
-TOKEN="$(op item get 'Cloudflare Manage DNS' --vault ravenmask --fields credential --reveal)"
-curl -s https://api.cloudflare.com/client/v4/user/tokens/verify \
-  -H "Authorization: Bearer $TOKEN"
+dig +short nwalker.cc
+dig +short staging.nwalker.cc
 ```
 
-If zone creation fails with `com.cloudflare.api.account.zone.create`, update the token in Cloudflare with account-level zone create/edit permission before continuing.
+If a production outage appears DNS-related, verify Cloudflare records for the existing `nwalker.cc` zone using a shell-scoped token from 1Password. Do not export tokens globally.
 
-## Cloudflare Zone Migration
+## Health Smoke Check
 
-1. Export current DNS records from the existing provider.
-2. Add the zone in Cloudflare.
-3. Recreate required records.
-4. Configure redirects and canonical host rules.
-5. Change nameservers at Squarespace.
-6. Verify DNS, TLS, canonical tags, and redirects after propagation.
+```bash
+curl -I https://nwalker.cc/
+curl -I https://nwalker.cc/ecosystem
+curl -I https://staging.nwalker.cc/
+curl -s https://nwalker.cc/sitemap.xml | rg 'ecosystem|definitions|frameworks|patterns'
+```

--- a/docs/domain-portfolio.md
+++ b/docs/domain-portfolio.md
@@ -8,8 +8,8 @@ This document separates Nathan Walker personal identity, Ravenhelm company ident
 - Build Ravenhelm company domains in Ravenhelm-owned repositories and deployments.
 - Build Runestack product domains in Runestack product repositories and deployments.
 - Build Domain Intelligence Schema and Artimetrics as citable methodology/spec properties.
-- Use shared conventions for metadata, legal footers, analytics naming, Cloudflare configuration, uptime monitors, redirect rules, and content templates.
-- Move DNS to Cloudflare where possible while preserving registrar ownership at Squarespace unless a transfer has a clear operational reason.
+- Use shared conventions for metadata, legal footers, analytics naming, uptime monitors, redirect rules, and content templates.
+- Do not treat Cloudflare migration as a domain-portfolio objective. DNS and hosting stay where they are when a domain is already healthy and intentional.
 
 ## Domain Matrix
 
@@ -23,11 +23,11 @@ This document separates Nathan Walker personal identity, Ravenhelm company ident
 | `runestack.ai` | Product | Production Runestack domain | Canonical product site | Critical | Product promise, architecture overview, use cases |
 | `runestack.dev` | Product | Runestack dev/staging domain | Operational/dev domain; noindex by default | High | Preview index, release notes, access policy |
 | `domainintelligenceschema.org` | Methodology | Business-domain modeling methodology and schema | Canonical citable spec site | Critical | Definition, schema model, examples, FAQ, versioning |
-| `domainintelligenceschema.ai` | Methodology alias | AI-oriented alias | 301 to `domainintelligenceschema.org` | High | Cloudflare redirect rule |
+| `domainintelligenceschema.ai` | Methodology alias | AI-oriented alias | 301 to `domainintelligenceschema.org` | High | Provider-level redirect rule |
 | `artimetrics.ai` | Concept | Agent identification concept/spec | Canonical concept site | High | Definition, identity model, examples, DIS relationship |
 | `artimetrics.org` | Concept alias | Reserved neutral namespace | Redirect or reserve until distinct role exists | Medium | Redirect decision |
 | `ravenmask.ai` | Personal | Personal/lab identity | Canonical personal lab site | Medium | Lab positioning, projects index, public/private boundary |
-| `ravenmask.net` | Personal alias | Protective alias | 301 to `ravenmask.ai` | Low | Cloudflare redirect rule |
+| `ravenmask.net` | Personal alias | Protective alias | 301 to `ravenmask.ai` | Low | Provider-level redirect rule |
 | `hrafngrima.com` | Personal alias | Alternative personal domain | Reserve or redirect after identity decision | Low | Redirect target decision |
 | `theviking.ai` | Personal project | Camper domain | Separate personal project site | Medium | Camper identity, build notes, travel/log content |
 | `theviking.tools` | Personal project | Camper tools adjunct | Verify ownership and renewal before building | Low | Ownership verification |
@@ -60,22 +60,16 @@ Each first page should include:
 ## Build Order
 
 1. Publish this governance matrix and `nwalker.cc/ecosystem`.
-2. Move DNS zones into Cloudflare or document exceptions.
-3. Put immediate landing pages or redirects on all active domains.
-4. Build `domainintelligenceschema.org` as the first standalone authority site.
-5. Build `artimetrics.ai` as the second standalone authority site.
-6. Hold `agentropy` as an unowned concept until the naming and domain strategy are resolved.
-7. Build `ravenhelm.co` and `runestack.ai` as public business/product surfaces.
+2. Keep `domainintelligenceschema.org` on its current healthy GitHub Pages setup.
+3. Put immediate landing pages or redirects on active domains only when they are not already intentional.
+4. Build `artimetrics.ai` as the next standalone authority concept when its positioning is ready.
+5. Hold `agentropy` as an unowned concept until the naming and domain strategy are resolved.
+6. Build Ravenhelm and Runestack public surfaces in their own repos when those workstreams are opened.
 
-## Cloudflare Migration Checklist
+## DNS And Hosting Policy
 
-- Current Cloudflare zones visible to the working token: `hrafngrima.com`, `nwalker.cc`, `ravenhelm.dev`, `theviking.ai`.
-- Current token blocker: the available `Cloudflare Manage DNS` token can verify successfully and read/manage existing DNS zones, but it does not have `com.cloudflare.api.account.zone.create`, so it cannot add new zones.
-- Token needed to continue automation: account-level zone create/edit access plus DNS edit access for the target account.
-- Add each domain as a Cloudflare zone.
-- Change nameservers at Squarespace.
-- Recreate required DNS records before nameserver cutover.
-- Configure redirects for alias domains.
-- Configure `robots.txt` and AI crawler policy per domain role.
-- Add uptime checks for public canonical domains.
-- Validate `200`, `301`, TLS, canonical tags, and sitemap behavior after cutover.
+- `nwalker.cc` uses Cloudflare today; keep that path healthy because it is part of this repo's production architecture.
+- Other domains do not move to Cloudflare by default.
+- `domainintelligenceschema.org` is explicitly healthy on GitHub Pages and should stay there unless a concrete operational reason appears.
+- Redirects should be implemented at the current provider for each domain unless that provider cannot support the needed behavior.
+- Add uptime checks for public canonical domains, but do not confuse monitoring with DNS migration.

--- a/src/lib/domain-portfolio.ts
+++ b/src/lib/domain-portfolio.ts
@@ -110,7 +110,7 @@ export const domainPortfolio: DomainPortfolioEntry[] = [
     livePolicy: '301 redirect to domainintelligenceschema.org.',
     canonicalTarget: 'https://domainintelligenceschema.org',
     priority: 'high',
-    contentPlan: ['Redirect only', 'Preserve ownership', 'Cloudflare redirect rule'],
+    contentPlan: ['Redirect only', 'Preserve ownership', 'Provider-level redirect rule'],
   },
   {
     domain: 'artimetrics.ai',


### PR DESCRIPTION
## Summary
- Remove stale domain-wide Cloudflare migration language from active portfolio docs.
- Mark domainintelligenceschema.org as healthy on its current GitHub Pages setup, not a migration target.
- Refocus the active checklist on nwalker.cc health, monitoring, and strategic refinement.

## Test plan
- [x] `git diff --check`
- [x] Live smoke check: `https://nwalker.cc/`, `https://nwalker.cc/ecosystem`, and `https://staging.nwalker.cc/` returned 200
- [ ] `pnpm lint/test/build` not run locally because this worktree does not have installed dependencies; CI validate will run on PR

Generated with Codex.