### PR TITLE
feat: add accountable agent demo

### DIFF
--- a/src/app/__tests__/metadata-routes.test.ts
+++ b/src/app/__tests__/metadata-routes.test.ts
@@ -22,6 +22,7 @@ describe('metadata routes', () => {
     expect(urls).toContain('https://nwalker.cc/enterprise')
     expect(urls).toContain('https://nwalker.cc/philosophy')
     expect(urls).toContain('https://nwalker.cc/runestack')
+    expect(urls).toContain('https://nwalker.cc/demo')
     expect(urls).toContain('https://nwalker.cc/ecosystem')
     expect(urls).toContain('https://nwalker.cc/definitions')
     expect(urls).toContain('https://nwalker.cc/frameworks')

--- a/src/app/demo/page.tsx
+++ b/src/app/demo/page.tsx
@@ -1,0 +1,64 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { AccountabilityDemo } from '@/components/demo/AccountabilityDemo'
+
+export const metadata: Metadata = {
+  title: 'Accountability Demo | Nathan Walker',
+  description: 'A working browser demo of governed agent execution: authority checks, policy gates, mutation containment, and evidence receipts.',
+  alternates: {
+    canonical: '/demo',
+  },
+}
+
+export default function DemoPage() {
+  return (
+    <main className="px-8">
+      <section className="max-w-[1120px] mx-auto py-24 md:py-32">
+        <p className="text-[var(--text-muted)] text-sm font-medium tracking-widest uppercase mb-4">
+          Working Demo
+        </p>
+        <h1 className="text-[var(--text-primary)] text-3xl md:text-5xl font-light tracking-tight leading-tight mb-8 max-w-[820px]">
+          Governed agents should prove why they are allowed to act.
+        </h1>
+        <p className="text-[var(--text-secondary)] text-lg md:text-xl leading-relaxed mb-6 max-w-[840px]">
+          This is a deterministic browser demo of the control-plane pattern behind accountable AI: intent enters, authority is checked, policy gates decide, and the system emits an evidence receipt before any tool is granted.
+        </p>
+        <p className="text-[var(--text-muted)] text-base leading-relaxed mb-12 max-w-[760px]">
+          Change the request, authority level, value, justification, and containment controls. The verdict updates immediately. The point is not model cleverness; it is bounded execution.
+        </p>
+
+        <AccountabilityDemo />
+
+        <div className="grid md:grid-cols-3 gap-8 mt-16 border-t border-[var(--edge)] pt-12">
+          <section>
+            <h2 className="text-[var(--text-primary)] text-lg font-semibold mb-3">
+              What It Demonstrates
+            </h2>
+            <p className="text-[var(--text-secondary)] text-sm leading-relaxed">
+              A governed agent does not receive broad tool access. It earns a scoped grant only after authority, data, value, and mutation checks pass.
+            </p>
+          </section>
+          <section>
+            <h2 className="text-[var(--text-primary)] text-lg font-semibold mb-3">
+              What It Avoids
+            </h2>
+            <p className="text-[var(--text-secondary)] text-sm leading-relaxed">
+              No black-box execution, no silent side effects, and no unreviewable tool calls. Blocked and escalated requests still produce evidence.
+            </p>
+          </section>
+          <section>
+            <h2 className="text-[var(--text-primary)] text-lg font-semibold mb-3">
+              Where It Leads
+            </h2>
+            <p className="text-[var(--text-secondary)] text-sm leading-relaxed mb-4">
+              This is the portfolio-safe version of the Runestack thesis: authority, accountability, and auditability as execution primitives.
+            </p>
+            <Link href="/runestack" className="text-[var(--primary)] text-sm font-medium hover:underline underline-offset-4">
+              Read the Runestack thesis →
+            </Link>
+          </section>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/src/app/runestack/page.tsx
+++ b/src/app/runestack/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import Link from 'next/link'
 
 export const metadata: Metadata = {
   title: 'Runestack | Nathan Walker',
@@ -122,35 +123,24 @@ export default function RunestackPage() {
           </div>
         </section>
 
-        {/* Section C — Voice Demo Stub */}
+        {/* Section C — Working Demo */}
         <section className="border-t border-[var(--edge)] pt-16 mt-20">
           <p className="text-[var(--text-muted)] text-sm font-medium tracking-widest uppercase mb-4">
             Demo
           </p>
           <h2 className="text-[var(--text-primary)] text-2xl md:text-3xl font-semibold tracking-tight mb-6">
-            Experience a Governed Agent
+            Run the Governed-Agent Demo
           </h2>
           <p className="text-[var(--text-secondary)] text-lg leading-relaxed mb-8">
-            A voice-enabled AI agent operating under full governance constraints — delegation chains, signed receipts, and real-time audit. Built on LiveKit, LangGraph, Deepgram ASR, and ElevenLabs TTS.
-          </p>
-          <p className="text-[var(--text-secondary)] text-base leading-relaxed mb-4">
-            The demo will showcase an agent that can answer questions about your environment, execute controlled actions, and produce a verifiable audit trail of everything it did and why.
+            The portfolio now includes a working browser demo of the control-plane pattern: authority checks, policy gates, mutation containment, and evidence receipts before tool access is granted.
           </p>
 
-          <div className="border border-[var(--edge)] px-6 py-8 mt-8">
-            <p className="text-[var(--text-primary)] text-lg font-semibold mb-3">
-              Coming Soon
-            </p>
-            <p className="text-[var(--text-secondary)] text-base leading-relaxed mb-6">
-              The interactive demo is under development. If you&apos;d like early access, reach out directly.
-            </p>
-            <a
-              href="mailto:nate@nwalker.cc?subject=Runestack%20Demo%20—%20Early%20Access"
-              className="text-[var(--primary)] text-base font-medium hover:underline underline-offset-4"
-            >
-              Request Early Access →
-            </a>
-          </div>
+          <Link
+            href="/demo"
+            className="text-[var(--primary)] text-base font-medium hover:underline underline-offset-4"
+          >
+            Open the Demo →
+          </Link>
         </section>
       </div>
     </main>

--- a/src/components/demo/AccountabilityDemo.tsx
+++ b/src/components/demo/AccountabilityDemo.tsx
@@ -1,0 +1,275 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import {
+  type ActorRole,
+  demoScenarios,
+  evaluateDemoRequest,
+  getScenario,
+} from '@/lib/demo/accountability'
+
+const actorOptions: { value: ActorRole; label: string }[] = [
+  { value: 'analyst', label: 'Analyst' },
+  { value: 'manager', label: 'Manager' },
+  { value: 'admin', label: 'Admin' },
+]
+
+const verdictStyles = {
+  approved: 'text-[var(--status-success)] border-[rgba(45,203,112,0.35)] bg-[rgba(45,203,112,0.08)]',
+  escalated: 'text-[var(--status-warning)] border-[rgba(227,179,65,0.38)] bg-[rgba(227,179,65,0.08)]',
+  blocked: 'text-[var(--status-error)] border-[rgba(255,77,79,0.38)] bg-[rgba(255,77,79,0.08)]',
+}
+
+const findingStyles = {
+  pass: 'text-[var(--status-success)]',
+  warn: 'text-[var(--status-warning)]',
+  fail: 'text-[var(--status-error)]',
+}
+
+export function AccountabilityDemo() {
+  const [scenarioId, setScenarioId] = useState(demoScenarios[0].id)
+  const [actorRole, setActorRole] = useState<ActorRole>('manager')
+  const [amount, setAmount] = useState(demoScenarios[0].defaultAmount)
+  const [hasJustification, setHasJustification] = useState(true)
+  const [containmentEnabled, setContainmentEnabled] = useState(true)
+  const [runCount, setRunCount] = useState(1)
+
+  const scenario = getScenario(scenarioId)
+  const evaluation = useMemo(
+    () =>
+      evaluateDemoRequest({
+        scenarioId,
+        actorRole,
+        amount,
+        hasJustification,
+        containmentEnabled,
+      }),
+    [scenarioId, actorRole, amount, hasJustification, containmentEnabled],
+  )
+
+  function markInteraction() {
+    setRunCount((count) => count + 1)
+  }
+
+  function selectScenario(id: string) {
+    const next = getScenario(id)
+    setScenarioId(id)
+    setAmount(next.defaultAmount)
+    setActorRole(next.requiredRole)
+    setHasJustification(next.dataClass !== 'regulated')
+    setContainmentEnabled(true)
+    markInteraction()
+  }
+
+  return (
+    <div className="border border-[var(--edge)] bg-[var(--surface)]">
+      <div className="grid lg:grid-cols-[360px_1fr]">
+        <aside className="border-b lg:border-b-0 lg:border-r border-[var(--edge)] p-5 md:p-6">
+          <div className="mb-8">
+            <p className="text-[var(--text-muted)] text-xs font-medium tracking-widest uppercase mb-3">
+              Request
+            </p>
+            <div className="grid gap-2">
+              {demoScenarios.map((item) => (
+                <button
+                  key={item.id}
+                  type="button"
+                  onClick={() => selectScenario(item.id)}
+                  className={`text-left border px-4 py-3 transition-colors cursor-pointer ${
+                    scenarioId === item.id
+                      ? 'border-[var(--primary)] bg-[rgba(30,103,255,0.08)]'
+                      : 'border-[var(--edge)] hover:border-[var(--text-muted)]'
+                  }`}
+                >
+                  <span className="block text-[var(--text-primary)] text-sm font-medium mb-1">
+                    {item.name}
+                  </span>
+                  <span className="block text-[var(--text-muted)] text-xs leading-relaxed">
+                    {item.tool}
+                  </span>
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="space-y-6">
+            <label className="block">
+              <span className="text-[var(--text-muted)] text-xs font-medium tracking-widest uppercase block mb-2">
+                Actor Authority
+              </span>
+              <select
+                value={actorRole}
+                onChange={(event) => {
+                  setActorRole(event.target.value as ActorRole)
+                  markInteraction()
+                }}
+                className="w-full bg-[var(--background)] border border-[var(--edge)] px-3 py-3 text-[var(--text-primary)] text-sm focus:outline-none focus:border-[var(--primary)]"
+              >
+                {actorOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="block">
+              <span className="text-[var(--text-muted)] text-xs font-medium tracking-widest uppercase block mb-2">
+                Request Value
+              </span>
+              <input
+                type="range"
+                min="0"
+                max="20000"
+                step="500"
+                value={amount}
+                onChange={(event) => {
+                  setAmount(Number(event.target.value))
+                  markInteraction()
+                }}
+                className="w-full accent-[var(--primary)]"
+              />
+              <span className="text-[var(--text-primary)] font-[family-name:var(--font-mono)] text-sm">
+                ${amount.toLocaleString()}
+              </span>
+            </label>
+
+            <label className="flex items-start gap-3 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={hasJustification}
+                onChange={(event) => {
+                  setHasJustification(event.target.checked)
+                  markInteraction()
+                }}
+                className="mt-1 accent-[var(--primary)]"
+              />
+              <span>
+                <span className="block text-[var(--text-primary)] text-sm font-medium">
+                  Business justification attached
+                </span>
+                <span className="block text-[var(--text-muted)] text-xs leading-relaxed">
+                  Required for regulated data paths.
+                </span>
+              </span>
+            </label>
+
+            <label className="flex items-start gap-3 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={containmentEnabled}
+                onChange={(event) => {
+                  setContainmentEnabled(event.target.checked)
+                  markInteraction()
+                }}
+                className="mt-1 accent-[var(--primary)]"
+              />
+              <span>
+                <span className="block text-[var(--text-primary)] text-sm font-medium">
+                  Mutation containment enabled
+                </span>
+                <span className="block text-[var(--text-muted)] text-xs leading-relaxed">
+                  External effects require rollback or approval.
+                </span>
+              </span>
+            </label>
+          </div>
+        </aside>
+
+        <section className="p-5 md:p-8">
+          <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-5 mb-8">
+            <div>
+              <p className="text-[var(--text-muted)] text-xs font-medium tracking-widest uppercase mb-2">
+                Governed Evaluation #{runCount.toString().padStart(2, '0')}
+              </p>
+              <h2 className="text-[var(--text-primary)] text-2xl md:text-3xl font-semibold tracking-tight mb-3">
+                {scenario.name}
+              </h2>
+              <p className="text-[var(--text-secondary)] text-base leading-relaxed max-w-[680px]">
+                {scenario.intent}
+              </p>
+            </div>
+            <div className={`border px-4 py-2 text-sm font-[family-name:var(--font-mono)] uppercase tracking-widest ${verdictStyles[evaluation.verdict]}`}>
+              {evaluation.verdict}
+            </div>
+          </div>
+
+          <div className="grid md:grid-cols-4 border border-[var(--edge)] mb-8">
+            {[
+              ['Intent', 'parsed'],
+              ['Authority', actorRole],
+              ['Policy', evaluation.verdict === 'blocked' ? 'failed' : 'checked'],
+              ['Tool Grant', evaluation.receipt.allowedTool ? 'scoped' : 'withheld'],
+            ].map(([label, value], index) => (
+              <div key={label} className={`p-4 ${index < 3 ? 'border-b md:border-b-0 md:border-r border-[var(--edge)]' : ''}`}>
+                <p className="text-[var(--text-muted)] text-xs font-medium tracking-widest uppercase mb-2">
+                  {label}
+                </p>
+                <p className="text-[var(--text-primary)] text-sm font-[family-name:var(--font-mono)]">
+                  {value}
+                </p>
+              </div>
+            ))}
+          </div>
+
+          <p className="text-[var(--text-primary)] text-lg leading-relaxed mb-8">
+            {evaluation.summary}
+          </p>
+
+          <div className="grid lg:grid-cols-[1fr_320px] gap-8">
+            <div>
+              <h3 className="text-[var(--text-primary)] text-lg font-semibold mb-4">
+                Control Checks
+              </h3>
+              <div className="space-y-4">
+                {evaluation.findings.map((finding) => (
+                  <article key={finding.label} className="border-t border-[var(--edge)] pt-4">
+                    <div className="flex items-baseline justify-between gap-4 mb-2">
+                      <h4 className="text-[var(--text-primary)] text-sm font-medium">
+                        {finding.label}
+                      </h4>
+                      <span className={`text-xs font-[family-name:var(--font-mono)] uppercase tracking-widest ${findingStyles[finding.status]}`}>
+                        {finding.status}
+                      </span>
+                    </div>
+                    <p className="text-[var(--text-muted)] text-sm leading-relaxed">
+                      {finding.detail}
+                    </p>
+                  </article>
+                ))}
+              </div>
+            </div>
+
+            <aside className="border border-[var(--edge)] bg-[var(--background)] p-5 h-fit">
+              <h3 className="text-[var(--text-primary)] text-lg font-semibold mb-5">
+                Evidence Receipt
+              </h3>
+              <dl className="space-y-4">
+                <div>
+                  <dt className="text-[var(--text-muted)] text-xs font-medium tracking-widest uppercase mb-1">Receipt</dt>
+                  <dd className="text-[var(--text-primary)] font-[family-name:var(--font-mono)] text-sm">{evaluation.receipt.id}</dd>
+                </div>
+                <div>
+                  <dt className="text-[var(--text-muted)] text-xs font-medium tracking-widest uppercase mb-1">Authority Chain</dt>
+                  <dd className="text-[var(--text-secondary)] text-sm">{evaluation.receipt.authorityChain.join(' -> ')}</dd>
+                </div>
+                <div>
+                  <dt className="text-[var(--text-muted)] text-xs font-medium tracking-widest uppercase mb-1">Tool</dt>
+                  <dd className="text-[var(--text-secondary)] text-sm break-all">{evaluation.receipt.allowedTool ?? 'withheld pending control resolution'}</dd>
+                </div>
+                <div>
+                  <dt className="text-[var(--text-muted)] text-xs font-medium tracking-widest uppercase mb-1">Policies</dt>
+                  <dd className="text-[var(--text-secondary)] text-sm">{evaluation.receipt.policyIds.join(', ')}</dd>
+                </div>
+                <div>
+                  <dt className="text-[var(--text-muted)] text-xs font-medium tracking-widest uppercase mb-1">Evidence Hash</dt>
+                  <dd className="text-[var(--text-primary)] font-[family-name:var(--font-mono)] text-sm">{evaluation.receipt.evidenceHash}</dd>
+                </div>
+              </dl>
+            </aside>
+          </div>
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -15,6 +15,7 @@ const siteLinks = [
   { label: 'Frameworks', href: '/frameworks' },
   { label: 'Patterns', href: '/patterns' },
   { label: 'Enterprise Work', href: '/enterprise' },
+  { label: 'Demo', href: '/demo' },
   { label: 'Runestack', href: '/runestack' },
   { label: 'Ecosystem', href: '/ecosystem' },
 ]

--- a/src/components/layout/Nav.tsx
+++ b/src/components/layout/Nav.tsx
@@ -30,13 +30,14 @@ const dropdowns: NavDropdown[] = [
     items: [
       { label: 'Enterprise', href: '/enterprise', desc: 'Selected projects built and shipped' },
       { label: 'Runestack', href: '/runestack', desc: 'Accountability layer for AI agents' },
+      { label: 'Demo', href: '/demo', desc: 'Interactive governed-agent control plane' },
       { label: 'Ecosystem', href: '/ecosystem', desc: 'Domain, company, product, and concept map' },
     ],
   },
 ]
 
 const directLinks: NavLink[] = [
-  { label: 'Resume', href: '/resume.pdf' },
+  { label: 'Portfolio', href: '/enterprise' },
   { label: 'Contact', href: '/#contact' },
 ]
 

--- a/src/components/layout/__tests__/Nav.test.tsx
+++ b/src/components/layout/__tests__/Nav.test.tsx
@@ -11,7 +11,7 @@ describe('Nav', () => {
 
   it('renders direct links', () => {
     render(<Nav />)
-    expect(screen.getAllByText('Resume').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Portfolio').length).toBeGreaterThan(0)
     expect(screen.getAllByText('Contact').length).toBeGreaterThan(0)
   })
 

--- a/src/components/sections/AccountableAI.tsx
+++ b/src/components/sections/AccountableAI.tsx
@@ -25,10 +25,10 @@ export function AccountableAI() {
           </p>
         </div>
         <Link
-          href="/runestack"
+          href="/demo"
           className="text-[var(--primary)] text-base font-medium hover:underline underline-offset-4"
         >
-          See the Five Invariants →
+          Run the Accountability Demo →
         </Link>
       </div>
     </section>

--- a/src/lib/demo/__tests__/accountability.test.ts
+++ b/src/lib/demo/__tests__/accountability.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { evaluateDemoRequest } from '../accountability'
+
+describe('evaluateDemoRequest', () => {
+  it('approves a contained manager refund inside threshold', () => {
+    const result = evaluateDemoRequest({
+      scenarioId: 'refund',
+      actorRole: 'manager',
+      amount: 4200,
+      hasJustification: true,
+      containmentEnabled: true,
+    })
+
+    expect(result.verdict).toBe('approved')
+    expect(result.receipt.allowedTool).toBe('billing.refund.create')
+  })
+
+  it('escalates external mutation when containment is disabled', () => {
+    const result = evaluateDemoRequest({
+      scenarioId: 'refund',
+      actorRole: 'manager',
+      amount: 4200,
+      hasJustification: true,
+      containmentEnabled: false,
+    })
+
+    expect(result.verdict).toBe('escalated')
+    expect(result.receipt.allowedTool).toBeNull()
+    expect(result.findings.some((finding) => finding.label === 'Mutation containment')).toBe(true)
+  })
+
+  it('blocks regulated exports without justification', () => {
+    const result = evaluateDemoRequest({
+      scenarioId: 'phi-export',
+      actorRole: 'admin',
+      amount: 12000,
+      hasJustification: false,
+      containmentEnabled: true,
+    })
+
+    expect(result.verdict).toBe('blocked')
+    expect(result.receipt.allowedTool).toBeNull()
+  })
+})

--- a/src/lib/demo/accountability.ts
+++ b/src/lib/demo/accountability.ts
@@ -1,0 +1,204 @@
+export type ActorRole = 'analyst' | 'manager' | 'admin'
+export type Verdict = 'approved' | 'escalated' | 'blocked'
+
+export interface DemoScenario {
+  id: string
+  name: string
+  intent: string
+  tool: string
+  dataClass: 'public' | 'confidential' | 'regulated'
+  requiredRole: ActorRole
+  defaultAmount: number
+  approvalLimit: number
+  mutationScope: 'none' | 'internal' | 'external'
+  policyIds: string[]
+}
+
+export interface DemoInput {
+  scenarioId: string
+  actorRole: ActorRole
+  amount: number
+  hasJustification: boolean
+  containmentEnabled: boolean
+}
+
+export interface DemoFinding {
+  label: string
+  status: 'pass' | 'warn' | 'fail'
+  detail: string
+}
+
+export interface DemoEvaluation {
+  scenario: DemoScenario
+  verdict: Verdict
+  summary: string
+  findings: DemoFinding[]
+  receipt: {
+    id: string
+    authorityChain: string[]
+    allowedTool: string | null
+    policyIds: string[]
+    evidenceHash: string
+  }
+}
+
+export const actorRank: Record<ActorRole, number> = {
+  analyst: 1,
+  manager: 2,
+  admin: 3,
+}
+
+export const demoScenarios: DemoScenario[] = [
+  {
+    id: 'refund',
+    name: 'Customer Refund',
+    intent: 'Issue a customer refund after a support agent detects duplicate billing.',
+    tool: 'billing.refund.create',
+    dataClass: 'confidential',
+    requiredRole: 'manager',
+    defaultAmount: 4200,
+    approvalLimit: 5000,
+    mutationScope: 'external',
+    policyIds: ['AUTH-210', 'FIN-044', 'MUT-118'],
+  },
+  {
+    id: 'deploy',
+    name: 'Production Deploy',
+    intent: 'Promote a generated service change into a production workload.',
+    tool: 'deploy.production.apply',
+    dataClass: 'confidential',
+    requiredRole: 'admin',
+    defaultAmount: 0,
+    approvalLimit: 0,
+    mutationScope: 'external',
+    policyIds: ['AUTH-300', 'CHANGE-022', 'MUT-118'],
+  },
+  {
+    id: 'phi-export',
+    name: 'Regulated Data Export',
+    intent: 'Export records for a downstream analytics workflow touching regulated data.',
+    tool: 'records.export.create',
+    dataClass: 'regulated',
+    requiredRole: 'admin',
+    defaultAmount: 12000,
+    approvalLimit: 10000,
+    mutationScope: 'external',
+    policyIds: ['AUTH-300', 'DATA-919', 'AUDIT-701'],
+  },
+]
+
+export function getScenario(id: string) {
+  return demoScenarios.find((scenario) => scenario.id === id) ?? demoScenarios[0]
+}
+
+function stableHash(value: string) {
+  let hash = 2166136261
+  for (let i = 0; i < value.length; i += 1) {
+    hash ^= value.charCodeAt(i)
+    hash = Math.imul(hash, 16777619)
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0')
+}
+
+export function evaluateDemoRequest(input: DemoInput): DemoEvaluation {
+  const scenario = getScenario(input.scenarioId)
+  const findings: DemoFinding[] = []
+  let hardBlock = false
+  let needsEscalation = false
+
+  if (actorRank[input.actorRole] >= actorRank[scenario.requiredRole]) {
+    findings.push({
+      label: 'Delegated authority',
+      status: 'pass',
+      detail: `${input.actorRole} authority satisfies ${scenario.requiredRole} requirement.`,
+    })
+  } else {
+    hardBlock = true
+    findings.push({
+      label: 'Delegated authority',
+      status: 'fail',
+      detail: `${input.actorRole} cannot invoke ${scenario.tool}; ${scenario.requiredRole} authority required.`,
+    })
+  }
+
+  if (scenario.approvalLimit > 0 && input.amount > scenario.approvalLimit) {
+    needsEscalation = true
+    findings.push({
+      label: 'Value threshold',
+      status: 'warn',
+      detail: `$${input.amount.toLocaleString()} exceeds the $${scenario.approvalLimit.toLocaleString()} automatic approval limit.`,
+    })
+  } else {
+    findings.push({
+      label: 'Value threshold',
+      status: 'pass',
+      detail: scenario.approvalLimit > 0 ? 'Request is inside the automatic approval limit.' : 'No financial threshold applies.',
+    })
+  }
+
+  if (scenario.dataClass === 'regulated' && !input.hasJustification) {
+    hardBlock = true
+    findings.push({
+      label: 'Regulated data basis',
+      status: 'fail',
+      detail: 'Regulated data requires an explicit business justification before execution.',
+    })
+  } else if (scenario.dataClass === 'regulated') {
+    findings.push({
+      label: 'Regulated data basis',
+      status: 'pass',
+      detail: 'Business justification is attached to the receipt.',
+    })
+  } else {
+    findings.push({
+      label: 'Data handling',
+      status: 'pass',
+      detail: `${scenario.dataClass} data class is compatible with this tool path.`,
+    })
+  }
+
+  if (scenario.mutationScope === 'external' && !input.containmentEnabled) {
+    needsEscalation = true
+    findings.push({
+      label: 'Mutation containment',
+      status: 'warn',
+      detail: 'External side effects require containment, rollback, or human approval.',
+    })
+  } else {
+    findings.push({
+      label: 'Mutation containment',
+      status: 'pass',
+      detail: scenario.mutationScope === 'none' ? 'Read-only request.' : 'Mutation boundary is declared and contained.',
+    })
+  }
+
+  const verdict: Verdict = hardBlock ? 'blocked' : needsEscalation ? 'escalated' : 'approved'
+  const allowedTool = verdict === 'approved' ? scenario.tool : null
+  const receiptSeed = [
+    scenario.id,
+    input.actorRole,
+    input.amount,
+    input.hasJustification,
+    input.containmentEnabled,
+    verdict,
+    scenario.policyIds.join(':'),
+  ].join('|')
+
+  return {
+    scenario,
+    verdict,
+    summary: {
+      approved: 'Request can execute. The agent receives a scoped tool grant and a signed evidence receipt.',
+      escalated: 'Request is not denied, but execution pauses for human approval at the control boundary.',
+      blocked: 'Request is blocked before tool access. The failed checks are still recorded as evidence.',
+    }[verdict],
+    findings,
+    receipt: {
+      id: `rcpt-${stableHash(receiptSeed).slice(0, 6)}`,
+      authorityChain: ['Nathan Walker', input.actorRole, 'governed agent'],
+      allowedTool,
+      policyIds: scenario.policyIds,
+      evidenceHash: stableHash(`${receiptSeed}|evidence`),
+    },
+  }
+}

--- a/src/lib/seo/site.ts
+++ b/src/lib/seo/site.ts
@@ -32,6 +32,12 @@ export const primaryPages = [
     priority: 0.7,
   },
   {
+    path: '/demo',
+    title: 'Accountability Demo | Nathan Walker',
+    description: 'A working browser demo of governed agent execution with authority checks, policy gates, mutation containment, and evidence receipts.',
+    priority: 0.8,
+  },
+  {
     path: '/ecosystem',
     title: 'Ecosystem | Nathan Walker',
     description: 'The domain and concept map around Nathan Walker, Ravenhelm, Runestack, Domain Intelligence Schema, and Artimetrics.',


### PR DESCRIPTION
## Summary
- add an interactive governed-agent accountability demo at /demo
- add deterministic demo evaluation logic with focused tests
- wire the demo into nav, footer, sitemap, homepage CTA, and Runestack page

## Validation
- pnpm test
- pnpm lint
- pnpm build
- curl -I http://127.0.0.1:3001/demo
- sitemap check includes /demo