### PR TITLE
fix(ui): prevent concatenated nav and metadata text

### DIFF
--- a/src/app/enterprise/page.tsx
+++ b/src/app/enterprise/page.tsx
@@ -80,12 +80,12 @@ export default function EnterprisePage() {
                 {project.description}
               </p>
               <div className="flex flex-wrap gap-3">
-                {project.tech.map((t) => (
+                {project.tech.map((t, index) => (
                   <span
                     key={t}
                     className="text-[var(--text-muted)] text-xs font-medium tracking-wide font-[family-name:var(--font-mono)]"
                   >
-                    {t}
+                    {index > 0 ? '· ' : ''}{t}
                   </span>
                 ))}
               </div>

--- a/src/app/runestack/page.tsx
+++ b/src/app/runestack/page.tsx
@@ -93,14 +93,12 @@ export default function RunestackPage() {
           <h3 className="text-[var(--text-primary)] text-lg font-semibold mb-6">Target Environments</h3>
           <div className="space-y-4 mb-16">
             {targets.map((t) => (
-              <div key={t.label} className="flex items-baseline gap-4">
-                <span className="text-[var(--text-primary)] font-medium text-sm font-[family-name:var(--font-mono)] min-w-[90px] shrink-0">
+              <p key={t.label} className="text-sm leading-relaxed">
+                <span className="text-[var(--text-primary)] font-medium font-[family-name:var(--font-mono)]">
                   {t.label}
                 </span>
-                <span className="text-[var(--text-muted)] text-sm">
-                  {t.desc}
-                </span>
-              </div>
+                <span className="text-[var(--text-muted)]"> - {t.desc}</span>
+              </p>
             ))}
           </div>
 

--- a/src/components/layout/Nav.tsx
+++ b/src/components/layout/Nav.tsx
@@ -100,7 +100,7 @@ function DropdownItem({ dropdown }: { dropdown: NavDropdown }) {
               <span className="text-[var(--text-primary)] text-sm font-medium block">
                 {item.label}
               </span>
-              <span className="text-[var(--text-muted)] text-xs block mt-0.5">
+              <span className="text-[var(--text-muted)] text-xs block mt-0.5 before:content-['-'] before:mr-1">
                 {item.desc}
               </span>
             </Link>


### PR DESCRIPTION
## Summary
- add explicit separator before nav dropdown descriptions
- render Runestack target rows with explicit  text
- add separators between enterprise tech tags so labels never flatten together

## Why
Staging/live pages showed label+description strings appearing concatenated in collapsed/expanded contexts (e.g. , ). This patch makes textual separation explicit so readability does not depend solely on visual layout gaps.

## Validation
- local diff reviewed for all affected pages/components
- build currently blocked by pre-existing tooling issue in token generation: missing  dependency from  in this environment
