### PR TITLE
feat: homepage v2.1 refinement pass, nav simplification, 38% metric, analyst strip

### DIFF
--- a/src/app/__tests__/page.test.tsx
+++ b/src/app/__tests__/page.test.tsx
@@ -3,11 +3,45 @@ import { render, screen } from '@testing-library/react'
 import Page from '../page'
 
 describe('Homepage', () => {
-  it('renders hero with thesis statement', () => {
+  it('renders hero with identity line and thesis statement', () => {
     const { container } = render(<Page />)
-    expect(screen.getByText('Nathan Walker')).toBeTruthy()
+    expect(screen.getAllByText('Nathan Walker').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByText('AI Governance & Enterprise Platforms')).toBeTruthy()
     expect(screen.getByText(/AI eliminated the cost of building/)).toBeTruthy()
     expect(container).toHaveTextContent(/It did not eliminate the cost of being wrong/)
+    expect(container.querySelector('h1 em, p em')).toBeNull() // no italic drama
+  })
+
+  it('renders What AI Did Not Collapse with the scar closing line', () => {
+    render(<Page />)
+    expect(screen.getByText('What AI Did Not Collapse')).toBeTruthy()
+    expect(screen.getByText('Security boundary design')).toBeTruthy()
+    expect(screen.getByText(/These decisions do not appear in the prompt/)).toBeTruthy()
+    expect(screen.getByText(/They appear in the scars/)).toBeTruthy()
+    expect(screen.queryByText(/These are not features/)).toBeNull()
+  })
+
+  it('renders Enterprise Proof metrics with the canonical conversion number', () => {
+    render(<Page />)
+    expect(screen.getByText('$50M+')).toBeTruthy()
+    expect(screen.getByText('$17M')).toBeTruthy()
+    expect(screen.getByText('38%')).toBeTruthy()
+    expect(screen.queryByText('76%')).toBeNull()
+    expect(screen.getByText(/View Enterprise Work/)).toBeTruthy()
+  })
+
+  it('renders the 2025 analyst recognition strip', () => {
+    render(<Page />)
+    expect(screen.getByText(/2025 Analyst Recognition/)).toBeTruthy()
+    expect(screen.getByText(/Everest Group/)).toBeTruthy()
+    expect(screen.getByText(/IDC MarketScape/)).toBeTruthy()
+    expect(screen.getByText(/Magic Quadrant/)).toBeTruthy()
+  })
+
+  it('keeps hardware language off the homepage', () => {
+    const { container } = render(<Page />)
+    expect(container).not.toHaveTextContent(/10Gb/i)
+    expect(container).not.toHaveTextContent(/GPU/i)
   })
 
   it('renders the Judgment Gap section', () => {
@@ -22,14 +56,6 @@ describe('Homepage', () => {
     expect(screen.getByText(/Accountable AI Is the Logical Conclusion/)).toBeTruthy()
     expect(screen.getByText(/governance becomes mandatory/)).toBeTruthy()
     expect(screen.getByText(/Permission without auditability is fragility/)).toBeTruthy()
-  })
-
-  it('renders Enterprise Proof metrics', () => {
-    render(<Page />)
-    expect(screen.getByText('$50M+')).toBeTruthy()
-    expect(screen.getByText('$17M')).toBeTruthy()
-    expect(screen.getByText('76%')).toBeTruthy()
-    expect(screen.getByText(/View Enterprise Work/)).toBeTruthy()
   })
 
   it('renders Contact section', () => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 import { Hero } from '@/components/sections/Hero'
 import { JudgmentGap } from '@/components/sections/JudgmentGap'
+import { WhatAIDidNotCollapse } from '@/components/sections/WhatAIDidNotCollapse'
 import { EnterpriseProof } from '@/components/sections/EnterpriseProof'
 import { PlatformThinking } from '@/components/sections/PlatformThinking'
 import { AccountableAI } from '@/components/sections/AccountableAI'
@@ -10,6 +11,7 @@ export default function Home() {
     <main>
       <Hero />
       <JudgmentGap />
+      <WhatAIDidNotCollapse />
       <EnterpriseProof />
       <PlatformThinking />
       <AccountableAI />

--- a/src/components/layout/Nav.tsx
+++ b/src/components/layout/Nav.tsx
@@ -2,114 +2,15 @@
 
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { useState, useRef, useEffect } from 'react'
+import { useState, useEffect } from 'react'
 
-interface NavDropdown {
-  label: string
-  items: { label: string; href: string; desc: string }[]
-}
-
-interface NavLink {
-  label: string
-  href: string
-}
-
-const dropdowns: NavDropdown[] = [
-  {
-    label: 'Thinking',
-    items: [
-      { label: 'Philosophy', href: '/philosophy', desc: 'Frameworks, methodologies, and manifestos' },
-      { label: 'Architecture', href: '/architecture', desc: 'Systems philosophy and infrastructure proof' },
-      { label: 'Definitions', href: '/definitions', desc: 'Canonical AI governance vocabulary' },
-      { label: 'Frameworks', href: '/frameworks', desc: 'Named models for accountable AI systems' },
-      { label: 'Patterns', href: '/patterns', desc: 'Reusable enterprise AI architecture patterns' },
-    ],
-  },
-  {
-    label: 'Work',
-    items: [
-      { label: 'Enterprise', href: '/enterprise', desc: 'Selected projects built and shipped' },
-      { label: 'Runestack', href: '/runestack', desc: 'Accountability layer for AI agents' },
-      { label: 'Ecosystem', href: '/ecosystem', desc: 'Domain, company, product, and concept map' },
-    ],
-  },
-]
-
-const directLinks: NavLink[] = [
-  { label: 'Resume', href: '/resume.pdf' },
+const navLinks = [
+  { label: 'Philosophy', href: '/philosophy' },
+  { label: 'Enterprise', href: '/enterprise' },
+  { label: 'Architecture', href: '/architecture' },
+  { label: 'Runestack', href: '/runestack' },
   { label: 'Contact', href: '/#contact' },
 ]
-
-function DropdownItem({ dropdown }: { dropdown: NavDropdown }) {
-  const [open, setOpen] = useState(false)
-  const ref = useRef<HTMLDivElement>(null)
-  const timeoutRef = useRef<ReturnType<typeof setTimeout>>(null)
-  const pathname = usePathname()
-
-  const isActive = dropdown.items.some((item) => pathname === item.href)
-
-  function handleEnter() {
-    if (timeoutRef.current) clearTimeout(timeoutRef.current)
-    setOpen(true)
-  }
-
-  function handleLeave() {
-    timeoutRef.current = setTimeout(() => setOpen(false), 150)
-  }
-
-  return (
-    <div
-      ref={ref}
-      className="relative"
-      onMouseEnter={handleEnter}
-      onMouseLeave={handleLeave}
-    >
-      <button
-        onClick={() => setOpen((prev) => !prev)}
-        className={`flex items-center gap-1 text-sm transition-colors cursor-pointer ${
-          isActive
-            ? 'text-[var(--text-primary)]'
-            : 'text-[var(--text-secondary)] hover:text-[var(--text-primary)]'
-        }`}
-      >
-        {dropdown.label}
-        <svg
-          width="10"
-          height="6"
-          viewBox="0 0 10 6"
-          fill="none"
-          className={`transition-transform duration-200 ${open ? 'rotate-180' : ''}`}
-        >
-          <path d="M1 1L5 5L9 1" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-        </svg>
-      </button>
-
-      <div
-        className={`absolute top-full left-0 pt-3 transition-all duration-200 ${
-          open ? 'opacity-100 translate-y-0 pointer-events-auto' : 'opacity-0 -translate-y-1 pointer-events-none'
-        }`}
-      >
-        <div className="bg-[var(--surface)] border border-[var(--edge)] rounded-lg py-2 min-w-[240px] shadow-xl shadow-black/20">
-          {dropdown.items.map((item) => (
-            <Link
-              key={item.href}
-              href={item.href}
-              onClick={() => setOpen(false)}
-              className="block px-4 py-3 hover:bg-[var(--surface-variant)] transition-colors"
-            >
-              <span className="text-[var(--text-primary)] text-sm font-medium block">
-                {item.label}
-              </span>
-              <span className="text-[var(--text-muted)] text-xs block mt-0.5 before:content-['-'] before:mr-1">
-                {item.desc}
-              </span>
-            </Link>
-          ))}
-        </div>
-      </div>
-    </div>
-  )
-}
 
 export function Nav() {
   const pathname = usePathname()
@@ -143,14 +44,15 @@ export function Nav() {
 
         {/* Desktop nav */}
         <div className="hidden md:flex items-center gap-8">
-          {dropdowns.map((dd) => (
-            <DropdownItem key={`${dd.label}-${pathname}`} dropdown={dd} />
-          ))}
-          {directLinks.map((item) => (
+          {navLinks.map((item) => (
             <Link
               key={item.label}
               href={item.href}
-              className="text-[var(--text-secondary)] text-sm hover:text-[var(--text-primary)] transition-colors"
+              className={`text-sm transition-colors ${
+                pathname === item.href
+                  ? 'text-[var(--text-primary)]'
+                  : 'text-[var(--text-secondary)] hover:text-[var(--text-primary)]'
+              }`}
             >
               {item.label}
             </Link>
@@ -186,38 +88,17 @@ export function Nav() {
           mobileOpen ? 'max-h-[400px] opacity-100' : 'max-h-0 opacity-0'
         }`}
       >
-        <div className="px-8 py-6 border-t border-[var(--edge)] space-y-6">
-          {dropdowns.map((dd) => (
-            <div key={dd.label}>
-              <p className="text-[var(--text-muted)] text-xs font-medium tracking-widest uppercase mb-3">
-                {dd.label}
-              </p>
-              <div className="space-y-3 pl-2">
-                {dd.items.map((item) => (
-                  <Link
-                    key={item.href}
-                    href={item.href}
-                    onClick={() => setMobileOpen(false)}
-                    className="block text-[var(--text-secondary)] text-sm hover:text-[var(--text-primary)] transition-colors"
-                  >
-                    {item.label}
-                  </Link>
-                ))}
-              </div>
-            </div>
+        <div className="px-8 py-6 border-t border-[var(--edge)] space-y-4">
+          {navLinks.map((item) => (
+            <Link
+              key={item.label}
+              href={item.href}
+              onClick={() => setMobileOpen(false)}
+              className="block text-[var(--text-secondary)] text-sm hover:text-[var(--text-primary)] transition-colors"
+            >
+              {item.label}
+            </Link>
           ))}
-          <div className="space-y-3 pt-2 border-t border-[var(--edge)]">
-            {directLinks.map((item) => (
-              <Link
-                key={item.label}
-                href={item.href}
-                onClick={() => setMobileOpen(false)}
-                className="block text-[var(--text-secondary)] text-sm hover:text-[var(--text-primary)] transition-colors"
-              >
-                {item.label}
-              </Link>
-            ))}
-          </div>
         </div>
       </div>
     </nav>

--- a/src/components/layout/__tests__/Nav.test.tsx
+++ b/src/components/layout/__tests__/Nav.test.tsx
@@ -3,16 +3,19 @@ import { render, screen } from '@testing-library/react'
 import { Nav } from '../Nav'
 
 describe('Nav', () => {
-  it('renders dropdown group labels', () => {
+  it('renders the flat executive nav links', () => {
     render(<Nav />)
-    expect(screen.getAllByText('Thinking').length).toBeGreaterThan(0)
-    expect(screen.getAllByText('Work').length).toBeGreaterThan(0)
+    for (const label of ['Philosophy', 'Enterprise', 'Architecture', 'Runestack', 'Contact']) {
+      expect(screen.getAllByText(label).length).toBeGreaterThan(0)
+    }
   })
 
-  it('renders direct links', () => {
+  it('does not render the old dropdown groups or demoted items', () => {
     render(<Nav />)
-    expect(screen.getAllByText('Resume').length).toBeGreaterThan(0)
-    expect(screen.getAllByText('Contact').length).toBeGreaterThan(0)
+    expect(screen.queryByText('Thinking')).toBeNull()
+    expect(screen.queryByText('Work')).toBeNull()
+    expect(screen.queryByText('Resume')).toBeNull()
+    expect(screen.queryByText('Definitions')).toBeNull()
   })
 
   it('renders Nathan Walker name', () => {

--- a/src/components/sections/AnalystRecognition.tsx
+++ b/src/components/sections/AnalystRecognition.tsx
@@ -1,0 +1,54 @@
+const recognitions = [
+  {
+    org: 'Everest Group',
+    detail: 'PEAK Matrix® Leader for Conversational AI and AI Agents in CXM, 2025',
+    href: 'https://www.soundhound.com/everest-group-peak-matrix-leader-2025/',
+  },
+  {
+    org: 'IDC MarketScape',
+    detail: 'Leader, Conversational AI Platforms, 2025',
+    href: 'https://www.soundhound.com/idc-marketscape-leader-2025/',
+  },
+  {
+    org: 'Gartner',
+    detail: 'Magic Quadrant™ Visionary, Conversational AI Platforms, 2025',
+    href: 'https://www.soundhound.com/gartner-magic-quadrant-conversational-ai-2025/',
+  },
+]
+
+export function AnalystRecognition({ expanded = false }: { expanded?: boolean }) {
+  return (
+    <div>
+      <p className="text-[var(--text-muted)] text-sm font-medium tracking-widest uppercase mb-6">
+        2025 Analyst Recognition
+      </p>
+      <ul className="space-y-4 mb-8 list-none">
+        {recognitions.map((r) => (
+          <li key={r.org}>
+            <a
+              href={r.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group block"
+            >
+              <span className="text-[var(--text-primary)] text-base font-medium group-hover:underline underline-offset-4">
+                {r.org}
+              </span>
+              <span className="text-[var(--text-muted)] text-base"> — {r.detail}</span>
+            </a>
+          </li>
+        ))}
+      </ul>
+      <p className="text-[var(--text-secondary)] text-base leading-relaxed mb-4">
+        Pipeline, response platform, briefings, and live demos delivered end-to-end.
+      </p>
+      {expanded && (
+        <p className="text-[var(--text-muted)] text-xs leading-relaxed">
+          Gartner and Magic Quadrant are registered trademarks of Gartner, Inc. and/or its
+          affiliates and are used herein with permission via licensed vendor landing pages.
+          Analyst recognitions refer to SoundHound AI, where Nathan led global sales engineering.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/components/sections/EnterpriseProof.tsx
+++ b/src/components/sections/EnterpriseProof.tsx
@@ -1,8 +1,9 @@
 import Link from 'next/link'
+import { AnalystRecognition } from './AnalystRecognition'
 
 const metrics = [
   { value: '$50M+', label: 'Enterprise revenue delivered' },
-  { value: '76%', label: 'POC → Deal conversion' },
+  { value: '38%', label: 'POC → Deal conversion' },
   { value: '$17M', label: 'Visionworks' },
   { value: '$9M', label: 'Southern California Edison' },
   { value: '100+', label: 'Enterprise deployments' },
@@ -37,6 +38,9 @@ export function EnterpriseProof() {
         <p className="text-[var(--text-secondary)] text-lg leading-relaxed mb-12">
           These systems operated under regulatory scrutiny, contractual obligation, and executive visibility.
         </p>
+        <div className="border-t border-[var(--edge)] pt-12 mb-12">
+          <AnalystRecognition />
+        </div>
         <Link
           href="/enterprise"
           className="text-[var(--primary)] text-base font-medium hover:underline underline-offset-4"

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -1,17 +1,22 @@
 export function Hero() {
   return (
     <section className="min-h-screen flex items-center relative">
-      <div className="max-w-[720px] mx-auto px-8">
-        <h1 className="text-[var(--text-primary)] text-4xl md:text-5xl font-light tracking-tight leading-tight mb-16">
-          Nathan Walker
-        </h1>
-        <div className="space-y-2">
-          <p className="text-[var(--text-primary)] text-xl md:text-2xl font-light leading-relaxed">
-            AI eliminated the cost of building.
+      <div className="max-w-[1200px] mx-auto px-8 w-full">
+        <div className="max-w-[720px]">
+          <h1 className="text-[var(--text-primary)] text-4xl md:text-5xl font-light tracking-tight leading-tight mb-4">
+            Nathan Walker
+          </h1>
+          <p className="text-[var(--text-secondary)] text-lg md:text-xl mb-16">
+            AI Governance &amp; Enterprise Platforms
           </p>
-          <p className="text-[var(--text-primary)] text-xl md:text-2xl font-light leading-relaxed">
-            It did not eliminate the cost of being <em>wrong.</em>
-          </p>
+          <div className="space-y-2">
+            <p className="text-[var(--text-primary)] text-xl md:text-2xl font-light leading-relaxed">
+              AI eliminated the cost of building.
+            </p>
+            <p className="text-[var(--text-primary)] text-xl md:text-2xl font-light leading-relaxed">
+              It did not eliminate the cost of being wrong.
+            </p>
+          </div>
         </div>
       </div>
       <div className="absolute bottom-12 left-1/2 -translate-x-1/2 text-[var(--text-muted)] text-sm tracking-widest">

--- a/src/components/sections/PhilosophyAccordion.tsx
+++ b/src/components/sections/PhilosophyAccordion.tsx
@@ -154,14 +154,14 @@ const frameworks: Framework[] = [
   {
     tag: 'Methodology',
     title: 'Architecting Certainty',
-    summary: 'A repeatable framework for enterprise demos with a 76% POC win rate.',
+    summary: 'A repeatable framework for enterprise demos with a 38% POC win rate.',
     body: (
       <>
         <h4 className="text-[var(--text-primary)] text-lg font-semibold mb-3">
           The Ten Commandments of a Winning Demo
         </h4>
         <p className="text-[var(--text-secondary)] leading-relaxed mb-6">
-          After running hundreds of enterprise demos with a 76% POC win rate, I codified the methodology into a repeatable framework. Demos aren&apos;t presentations &mdash; they&apos;re the customer&apos;s first experience of working with you.
+          After running hundreds of enterprise demos with a 38% POC win rate, I codified the methodology into a repeatable framework. Demos aren&apos;t presentations &mdash; they&apos;re the customer&apos;s first experience of working with you.
         </p>
         <h4 className="text-[var(--text-primary)] text-lg font-semibold mb-3">Discovery-Led Approach</h4>
         <p className="text-[var(--text-secondary)] leading-relaxed mb-4">Every winning demo starts with rigorous discovery. Before opening a slide deck, understand:</p>

--- a/src/components/sections/PlatformThinking.tsx
+++ b/src/components/sections/PlatformThinking.tsx
@@ -1,10 +1,10 @@
 import Link from 'next/link'
 
 const capabilities = [
-  'Segmented VLAN trust zones',
+  'Segmented trust zones',
   'Isolated inference plane',
   'Kubernetes workload fabric',
-  'Zero-trust inter-VLAN policy enforcement',
+  'Deterministic deployment pipelines',
 ]
 
 export function PlatformThinking() {
@@ -15,7 +15,7 @@ export function PlatformThinking() {
           Infrastructure Is a Reflection of Judgment
         </h2>
         <p className="text-[var(--text-secondary)] text-lg leading-relaxed mb-12">
-          I operate a segmented, 10Gb, GPU-backed private AI fabric — not as a hobby, but as a proving ground for the systems I design for regulated environments.
+          I operate a segmented private AI fabric — not as a hobby, but as a proving ground for the systems I design for regulated environments.
         </p>
         <ul className="space-y-4 mb-16 list-none">
           {capabilities.map((item) => (

--- a/src/components/sections/WhatAIDidNotCollapse.tsx
+++ b/src/components/sections/WhatAIDidNotCollapse.tsx
@@ -22,10 +22,10 @@ export function WhatAIDidNotCollapse() {
         </ul>
         <div className="space-y-2">
           <p className="text-[var(--text-primary)] text-lg font-medium">
-            These are not features.
+            These decisions do not appear in the prompt.
           </p>
           <p className="text-[var(--text-primary)] text-lg font-medium">
-            They are guardrails.
+            They appear in the scars.
           </p>
         </div>
       </div>


### PR DESCRIPTION
Implements PLAN-001 items 3–4 and the 2026-05-13 recommendations §2/§3/§5:
- Hero: identity line, no italics, left-aligned (deltas 1–3)
- What AI Did Not Collapse restored with scar line (deltas 4–5)
- Hardware language off homepage (delta 6)
- Flat 5-item nav; corpus pages demoted to footer (delta 7)
- D1 resolved: 38% canonical (homepage + philosophy)
- 2025 Analyst Recognition strip, licensed SoundHound links only

🤖 Generated with [Claude Code](https://claude.com/claude-code)