### PR TITLE
ci: unit tests in CI, post-deploy smoke audit, synthetic monitoring

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -190,3 +190,23 @@ jobs:
             --cluster "$ECS_CLUSTER" \
             --services portfolio-production \
             --region "$AWS_REGION"
+
+  smoke-staging:
+    needs: deploy-staging
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Smoke test staging
+        run: |
+          set -o pipefail
+          ./scripts/smoke.sh https://staging.nwalker.cc | tee -a "$GITHUB_STEP_SUMMARY"
+
+  smoke-production:
+    needs: deploy-production
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Smoke test production
+        run: |
+          set -o pipefail
+          ./scripts/smoke.sh https://nwalker.cc | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,25 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Install dependencies (strip local token-forge dep — tokens.css is committed)
+        run: |
+          sed -i '/@nwalker\/token-forge/d' package.json
+          pnpm install --no-frozen-lockfile --ignore-scripts
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Unit tests
+        run: pnpm test
+
       - name: Lint Dockerfile
         uses: hadolint/hadolint-action@v3.3.0
         with:

--- a/.github/workflows/synthetic-health.yml
+++ b/.github/workflows/synthetic-health.yml
@@ -52,5 +52,6 @@ jobs:
           if [ -n "$EXISTING" ]; then
             gh issue comment "$EXISTING" --body-file body.md
           else
+            gh label create synthetic-failure --color B60205 --description "Raised by the synthetic health workflow" 2>/dev/null || true
             gh issue create --title "$TITLE" --label "synthetic-failure" --body-file body.md
           fi

--- a/.github/workflows/synthetic-health.yml
+++ b/.github/workflows/synthetic-health.yml
@@ -1,0 +1,56 @@
+name: Synthetic Health
+
+on:
+  schedule:
+    - cron: '*/30 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        env:
+          - { name: production, url: 'https://nwalker.cc' }
+          - { name: staging, url: 'https://staging.nwalker.cc' }
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Probe ${{ matrix.env.name }}
+        id: probe
+        run: |
+          set -o pipefail
+          ./scripts/smoke.sh "${{ matrix.env.url }}" | tee probe.log
+
+      - name: Raise alert issue on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ENV_NAME: ${{ matrix.env.name }}
+        run: |
+          TITLE="Synthetic health failure: $ENV_NAME"
+          RUN_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          PROBE_OUTPUT="$(cat probe.log 2>/dev/null || echo 'no probe output')"
+          TIMESTAMP="$(date -u +%FT%TZ)"
+
+          cat > body.md <<EOF
+          Probe failed at ${TIMESTAMP}
+
+          \`\`\`
+          ${PROBE_OUTPUT}
+          \`\`\`
+
+          Run: ${RUN_URL}
+          EOF
+
+          EXISTING=$(gh issue list --state open --search "in:title \"$TITLE\"" --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body-file body.md
+          else
+            gh issue create --title "$TITLE" --label "synthetic-failure" --body-file body.md
+          fi

--- a/docs/GAPS.md
+++ b/docs/GAPS.md
@@ -11,12 +11,11 @@
 | Related ADRs | ADR-001 |
 | Review Cadence | Monthly |
 | Retention Rule | Retain until superseded by resolved implementation evidence |
-| Last Reviewed | 2026-05-07 |
-| Next Review | 2026-06-07 |
+| Last Reviewed | 2026-06-12 |
+| Next Review | 2026-07-12 |
 
 ## High Priority
 
-- Monitoring and alerting must cover `nwalker.cc` and `staging.nwalker.cc` with notification evidence.
 - The homepage is close but not fully aligned to the final strategic refinement recommendations.
 - Primary navigation is still broader than the final executive structure.
 
@@ -31,3 +30,9 @@
 
 - Decide later whether adjacent personal domains need their own workstreams.
 - Let unrelated domain decisions stay outside this repo's active health checklist.
+
+## Resolved
+
+- 2026-06: Synthetic monitoring covers `nwalker.cc` and `staging.nwalker.cc` every 30 minutes
+  with GitHub-issue notification evidence (`synthetic-health.yml`); post-deploy smoke audits
+  run in the deploy pipeline.

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -79,3 +79,14 @@ curl -I https://nwalker.cc/ecosystem
 curl -I https://staging.nwalker.cc/
 curl -s https://nwalker.cc/sitemap.xml | rg 'ecosystem|definitions|frameworks|patterns'
 ```
+
+## Synthetic Monitoring
+
+- `.github/workflows/synthetic-health.yml` probes production and staging every 30 minutes
+  (root, key routes, sitemap, robots, canonical metadata, contact path — `scripts/smoke.sh`).
+- On failure it opens or updates a GitHub issue labeled `synthetic-failure`; GitHub
+  notification email to the repo owner is the notification evidence (GAPS-001 High item).
+- Post-deploy smoke jobs (`smoke-staging`, `smoke-production` in `deploy.yml`) run the same
+  script after every deploy and write results to the run summary — this is the PLAN-001 #5
+  production audit.
+- Manual run: `gh workflow run synthetic-health.yml` or `./scripts/smoke.sh https://nwalker.cc`.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "nwalker-next",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "pnpm@9.15.9",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Smoke test a deployed environment. Usage: scripts/smoke.sh https://staging.nwalker.cc
+set -euo pipefail
+
+BASE="${1:?usage: smoke.sh <base-url>}"
+FAIL=0
+
+check() {
+  local path="$1" expect="$2" desc="$3"
+  local body
+  if ! body=$(curl -fsSL --max-time 15 "$BASE$path"); then
+    echo "FAIL  $path — request failed ($desc)"
+    FAIL=1
+    return
+  fi
+  if echo "$body" | grep -q "$expect"; then
+    echo "ok    $path — $desc"
+  else
+    echo "FAIL  $path — missing '$expect' ($desc)"
+    FAIL=1
+  fi
+}
+
+check "/"             "Nathan Walker"          "root renders"
+check "/"             "id=\"contact\""         "contact path present"
+check "/philosophy"   "Nathan Walker"          "philosophy route"
+check "/enterprise"   "Nathan Walker"          "enterprise route"
+check "/architecture" "Nathan Walker"          "architecture route"
+check "/runestack"    "Nathan Walker"          "runestack route"
+check "/sitemap.xml"  "nwalker.cc/enterprise"  "sitemap lists key routes"
+check "/robots.txt"   "sitemap"                "robots advertises sitemap"
+check "/frameworks"   "rel=\"canonical\""      "canonical metadata present"
+
+exit "$FAIL"


### PR DESCRIPTION
Closes PLAN-001 #2 and #5 and the GAPS-001 High monitoring item:
- validate job now runs pnpm lint + vitest (token-forge file dep stripped, mirroring the Dockerfile)
- scripts/smoke.sh: 9-point audit (root, contact anchor, key routes, sitemap, robots, canonical) — verified locally
- smoke-staging / smoke-production jobs run it after every deploy, results to run summary
- synthetic-health.yml probes prod+staging every 30 min; failures open/update a deduped GitHub issue labeled synthetic-failure (email notification = evidence)
- RUNBOOK + GAPS updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)