### PR TITLE
chore: regenerate resume.pdf with canonical 38% metric

### DIFF
--- a/public/resume.pdf
+++ b/public/resume.pdf
@@ -2,7 +2,7 @@
 %“Œ‹ž ReportLab Generated PDF document (opensource)
 1 0 obj
 <<
-/F1 2 0 R /F2 3 0 R /F3 4 0 R /F4 5 0 R
+/F1 2 0 R /F2 3 0 R /F3 4 0 R
 >>
 endobj
 2 0 obj
@@ -22,12 +22,17 @@ endobj
 endobj
 5 0 obj
 <<
-/BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding /Name /F4 /Subtype /Type1 /Type /Font
+/Contents 11 0 R /MediaBox [ 0 0 612 792 ] /Parent 10 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
 >>
 endobj
 6 0 obj
 <<
-/Contents 11 0 R /MediaBox [ 0 0 612 792 ] /Parent 10 0 R /Resources <<
+/Contents 12 0 R /MediaBox [ 0 0 612 792 ] /Parent 10 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -37,7 +42,7 @@ endobj
 endobj
 7 0 obj
 <<
-/Contents 12 0 R /MediaBox [ 0 0 612 792 ] /Parent 10 0 R /Resources <<
+/Contents 13 0 R /MediaBox [ 0 0 612 792 ] /Parent 10 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -52,54 +57,62 @@ endobj
 endobj
 9 0 obj
 <<
-/Author (\(anonymous\)) /CreationDate (D:20260327014042+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260327014042+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+/Author (\(anonymous\)) /CreationDate (D:20260612075905-05'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260612075905-05'00') /Producer (ReportLab PDF Library - \(opensource\)) 
   /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
 >>
 endobj
 10 0 obj
 <<
-/Count 2 /Kids [ 6 0 R 7 0 R ] /Type /Pages
+/Count 3 /Kids [ 5 0 R 6 0 R 7 0 R ] /Type /Pages
 >>
 endobj
 11 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 3655
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2257
 >>
 stream
-GauHM>BAdn(4Q"]3"Mu;Ad;fkmd\J80]O>HK`IC["##Y`5d,lFBh9YI;Yf^,::DKZ&E(dd40INdU$b*OJ*/n[[\/Y1Q@<u.!2$0.ou.!UL?Sc@AuuBg3uCXEI_W,8?T),r2KTiQ^:J*m?F/otYAM,D]j#FICf&:_*6cRGa-"q4[LH9(`jT_&\anZP^H)npc+3^s0`D@,s1n861uBt][m-e@bN=1,Y[)%ld$@*&dc.l\@0*cjrcdk7Q;DRa-l,)`VSBskl?&\1fsOT,WnFM#a'8p/b^\WPg\UYbc%KGFjkAMZ7I\5Y&^Zdn&R=E^1q/eq?6sZ@F72m#[H>'`m-GQN&+A#;-P:#/";'R=$A$`A2`nMsNL&C9id9GJ1g?9#@)@:4_&uj;J9*#g-/<M&E>>TD#_1fmR&a&?Lk@L:&)\_<>dIPRi6:KPFX2rQ,Jja+]_g0sZ#u"D0*;+A)Hq<tf#:EK9Zi*,2nHER59sL;ehEU=8f0m!KZbCcl>=.Mj2XlK"#&TJ!Y6L>-Y+b^jfV"qh)J7OI#S\RE0%hMI=a%`.Y;piHmHY9$B`MZrIK]b+]epd%d5+kjI3-m"`roi%^ucJrYD;5Z9\>eEK+`&)+TQ?I-\.%X4HVpHL7S9.ZN_7%jhAa'm!mDE`a_8k!CDGB1?KKO:,_e/<L*9LfZ]hR"Z\IL6l/87f'u30o)SYkI?3/d!f'<.&'!Bg(rXir0@I0NaPo`]2d`q+M%u`/fQ"'I=tEdnKi7+:IHJL[Mo(jWo&:-&M3j5#;3/KnRimg4I_?!q"?8\0P?1qk+jepZ6fKD\.EMPR'0H(E(;Miee5H(-23^,mogK`%H3Z@AX)Y%"=tm]n3O]CQV;[:Hi'.,Jla(Pfb7^aRO+u&XiA=D1I':Q6N#N*Dkq]:E#9R1,6I?oo-:SN&$>J8)!O%I/jl8[obVDFKM&h30i*QI(?)G(1bj?aQKa@]NhbRIfiJcYT#KD-k1<@TBY2Zp=fp2?3j#l4;6-1I>:NEl-;V>HlI:$tK>AD=%WB,=iW&-F-)gi'*oP6?BJ:GhoS8(@;*,^2.@N0[BY'eH^0q^Ba1&XG"8a4P28ErcC1UFJNRWoud1A(/P8SC7OeAGF?^"j#Q6oD"WY@IcGsfD6B"$O3n#i9rfD`VOgnXoJMB4&G9t8ls.f@Z*cVUQJbR$;X5Wj,W6koLAj_L@gT:3hbdV+/4AY:,\A#R#[d0'2\GYFXH+8/S1AaK$Aa.qSHm2daieS:=cFn7[;69-QLSe(=H(I+gd\dt5fo[YElW46i+>RWb:M'ZoU8gl:/1=.)E5P'EMI>pa>-d=a>E.13g$DYX*/EJZh!Ros'EkNge'0$L0lR8=h3;"uHZq:Ys?.`ieV"Q!-#gFNP8<dR.$OoXF2mV2kI$L,UC@=BVho&=B#GPMS_.FK=LaI/)6\^`]&og</AYB5CL]K)+o]BTOG]9Z:\0'Y01NN?BI&K,>lJ/#0gfjhaaDYsopW0p[Y.!4U:eJ@s_9L5<f^C%6<m::mhJlPL8X:f!\50s@)IE:!@_idJ/WJY1(0>P*E>4@H7*BA=W5=Idp_nVW4H<0UXkS8FXg76b:W;\hL53LudK612l=HY->u5j(X)U[_F%V)?cs)N0fO@s1)"n27pk%`%WbH2NPMq=:$Y&`\E4%;bXB6#cUbW5VA:a7Z8NP\:@Ydt,r'%p;B/-NcPSs_<atq(@`>N)N1LY*O)M>6"O2qK3-6D">L)6CFnTR']\F#@@-bj6ncRO-pfZsWLCUt+lOB)(qkMn"s&]$Qf3t5lShcPq1,B%X_KJ-I8FNBLk<f%$rK/r5_C<b6A"g^(I=43;H>]+\qQ(&e%7STng5hp%Eb?/*9d"LJq#p\h)jlmTQA/Oo#[Aol6?#G=>N\GC.N\e>Z^S>7P=lq>+l<(:'<@hB\d3fV@.RV8%/VG>/507C/Lj_)Xllq8n/GUabQ5o>\mO>*<'0d8!C[#g\PY>ObM9o-sQJE:rbrB"E22lLeXe+<GmMqmYX<lYY\RK<#aHKD&WfKP6.='K9%M@ea_jTLU7,`T]6g'Oc9XHMk+XIe-N-Vca9I3#9_C&Hbkj%nq.2&:1N`"qV,23t^]id[$n?!4cJ:tY00;X&bTJ,#!9U&$WL=Is4)a!eh.L[\c2O<><KIfSsK'8XkKXi_d%5F?IJAg1D\ZU/G@($r:p'UhRJsG!f'E8$X7BP=aIi[0ka2.lCmu=IkXHp"2)E-.WoU.07IGLXO+MX\dAbS6t)kGg87]5a+rfU8+#PCX:DWWO'2_9$=p%GO%ENF[>/V"2)O/Y5kU[dB2_.5<KHuQ;"q/%r*&$`DXS?Cb2-.r>potg"-%sEP=^Eb?a%>P;'Gl+Q.iia&S7[S=nW_sc63Qpk<Gr7ac:c<G"rNtYe'+u>"gn'<u`iAG]X)-f^=a.&Je,@0f/+)Wh]ouG,nepf*h4bO^XV\(>+B"shH@($%,abF8\g:"c'j/_o7cS7eYRF&PGDapXShib`>.Sos]PYT7/9>oIQYMb&@UW_SZ7saR\A<-93eD6%<Sfa0<%UgT+QD[s=9GC&Hsp<[?6%9V%:5#pf(+/8]Q?":r"&3BPZ;'?`,?"a;\[TMWAVQ0E"A[Pp(^4;5@XJC7Qoum;ou+,PEpgM2h@Sk6e"\';;tp'>d.sdV+.c;\Z'h!?;-.Z3a*-DPl:LW&(i3%kMW\JGGa,S/rO^<*i2g1L,euk>fg@]!dB!jfO;dW0Eq66bUP<`2<D&X*lt8o&],5hFL!%k$nODf#*b@p-"YE*'mBj/eD4_N>MSY3naH>XEC,)]YOk0T>_04N04H>FA0tCW(5AST0&fjU?DEr&*XIGW7OWpg@`=-*'./F%iBpr2B0tOH%_Y<s]>q#QkJHJ:$AHso)<#t]'\pbX.;.V\jQ]`#C3LT"=]dIefST2<e,%-ijTsMA@ru;tc/(O?dmscrCUS1<2Z&p`#FKQ8F!?\lO]eUI8'5iY6?L0]k3C-TBt'iiTpk4HcB)Ri*5ksL*Rp1Km4mlEQATU$f6V]ZOLBl8EPNHfm++8actKW!"S453*3Qs1oUX#:46OKG$7d3a.*Qe-?0.m.ZQqsM/>."_@W6p4UIUo(1qhMU0iQ=-26uK?>$-*7Fo1G4\97\>BkTn@'?\fTq=0ZO#_,O;U-uYJd+Q:=4%_iRSP/bm(&Of*g.DZ1nQ?T3Y%"ZWFe?XRk\+mV#;Uk*psMR^_KhM_[[ot4lF_<VVGGqXQK:__*)PS<@@aU>()fRI'!`iIp=%i3VLrNIAFMfg:5qN*?c,eb2h;9Y/%,r:qNZF^.\6e-1a+<<-LNp*.DqPAVkBT;LfV.ZAcb%hcQC=+TZ7kq/5u=&-+0$uN4M&a'D!J-k?ZbT,.P@GpkrAqUT6S.HhI1@]`-^I"gS)o1DBq`ebd*8r8j&q-=^26add^lVIRY#2rR^s^l*AAH&HPVQh$!]:*!jc3aei.Jhe?kF95*A[.CS_39LU]p,hm8%Tf]b66?G&Gs2V+!k^P-Y@9fg/=*l&j^\::\ON!@6CBP%V>I'LO_G2FS'0:B"`_2BI&"s0"@F=!(*2+q,gU`Mg^-[-M=kT8]$8ikgoo.eSSC-]^\.[aQ7S,f3KL>XZPR#J?V)G`QB:(GP-1V>s,fL@(6cY=,+RmE@VufE=P13[]u<+Ch#e$;rX0%CDCP~>endstream
+Gatm<>Bedj&:Vs/R"s1H1a$RV6#cBmW_g_``hnKSoRW>t/?lOX-+aemHhuba]=M*P"h09^!qu%s0&Om#1CF4&^PR5q&qF?PE;:FRikTpN`3VRnhnXL9k1^hQT'Y2C&:GDI/7OfOT>:!/gq5p=Um@"g&sV^4@r&W8USSSfY_\4Lo+c@b8+TNO>PL7jq)lB@#P1/gr\O288'm(Lnb^+`rm3/)EQo:>^E4C].RSs15MOh!\HC/2m24q7j(T=lJ&$X=!VjU<JcW+rh[YO/oT@-(9Fgu-2@8KM'oAa=LjAj4<]nn_QTVs_%i3n=So+(qff[t;s0\Tbg$sekXc<X;jn?+N0/eX:]'d,JqR8gWqAKo#co>]@MRZk9E-uU!ia$Gp1SZ['0MXPhAPDZ:"#l1AQrI;(K7@hb@r`s-@PGBJ$Q.un88-"3>5?b3Npi1S3m3*6k;[R7=2^,dYcWna2rIk,L\1HEbTA@i=Mm%cY!@h'f*25?d?\Drb&YUSrP]schD9Dp^gJq3LF5QfJn<5;N8g]B.\a3D6VA"Q-IIlr;u'j;Q'`Bhn_Jan+(=SnKZW)>7TqgPg85jDJ<1_=o"PVDb(<tt70]5`/9,SdL7P,;`Zk\'M94iP:mF@o-/7@'4H_Ff5UO:UhZJk6;!Ph%M[X>>DF[tL:WE/jRZ>8%oUF6U1kCA@"GO%kQp**UGYh\aMCrD)YV^t\Q]aja9Y8Wb6A2%,,?Dkl7?Z^\cT"#7mfc)qS(97D0WhuRM\SQFGmZ[?i2ponh?-R*ENWlUd(__:o.g:[gqcc?]aK1TkcG\J*Jnm!5j6:_26?Ei9s-8<-k`+]/D(?4HZY6*f==u8:H/&"O$Gk-N$W$T0Qh_r^I#ft<]k#OW\[-Gbokc8V0Zc'W*C48%h*D/f=$>2ckmAg</sHL]mjEoTsZ#s-FM3Q4cOMm(C$BVlqth/L%8)4,"t<=*im0E'uCZCSMCuIR+TAOY9,1]m%fH);QQ+X;\r4e;G`e8849Emo5$#L<-o]s-nnU_7HVdP^GNAo<iauaL2A3r]3#S\laC$!l]1KuC2)Y'B1=?fWY:E\a5_OAFFEiH#(PgB;eC>AXgK;j,n\Ud#Ur<JifaT:5f`B"&T2D=#<F2_bJibG:*UkHKPok\WB-V?ENV;*hN@jhZ1E\8Zo2o2]^*Ghi<6JMfeEncAu$/C=JM"XbK@`JU,*H+#',[7+uPGSYq8[HH7JVW3gmQ^F@,%tOi;/,mNau&n72"!WX8&&cP.X;12Re83_.p@cl$fX8rd*f]2@?d3.CnkM/oN1KA`"GWBN.Q/RgKqCWq-Xb)U(<eZFC=cknV'l6K==q6<b]>kbhqcB7E7FbIZ$);?<7RESBl>JULM7A_n!c)'KiJoDY[Pd"sS<[&<KV[kXY4@)`qUBiH&`YF,*jFe:o5Fo[8*Vqu91LakH)tV$=[Yr+gXqB1o6e)LI^PWa-U0T@]^Ik+KQ82_1_X2J*m_WmEI7$[Me&Z;MB%PKB\f54J.%"2l!luW]eQU&GB,e<E4G?/K[YWB[^1Wnes0"H=>>iB`&TGXSP00\G0Zn!`n^Lu)r1aQ)F!N]^b">=Z8[\^3@GXV!q(8KW?2]:dEi$g0kAG=mHRSTYXG0\u.AQq`Gtt*nrEsZ;0tF2A`\aR?0TU>g[,^\<MFVK9f^tpj9m.g&HIBZH-sNi\=m'C%N!loHH9A:8A'6gc*fVB1VAW\1QtK4IV5;9C?$9)_MXQ,THIcKNdPtM;.GejrYV!'G$"rId)e\p!]DF=9GE_995/%K0a!Z59K>"]kHPFg+(/E)@7cZ2e%ap$A<O"bJ:N;"`Y3$DI4Kh8PYP_p>45QAhO.,g*$^epjdog`iVt99CGA^$<rYKG#kU_';(4&:0p!mQk']5GSQal5CSr>m_S6gtq.g`];;"1'rA/Ak.ok_Y-pm#NViL0*mU>:8M>]`G6]K47bSTS@uYGZ"]1,or2:L'>=VF\t>_Yi55.6D63s3)Ae%qa/\RRqp).V=;@fEoO'JfdcliL^EF(lNd<V`7TY8r)CV#%@-_`ha&Ei=oY;hOJm<..3LJg`>:%%13a8MRe6hNaU1W^K(H,1RXrJ5%9B,V:B+n7H5$hS5/-Dp)hGr5-nM2_kEtHSedm*\`n34L1`j4g6[6bEbOe/AV62J6:=coktA4JnRJ$%QD)-_C%2?3Ap3\6dKPX5$NJ#K-_cJuF$oQUf)"XeR?d?>)Jg4\)asZ]cal)liTMGrn<GTok=Dj;[!#ku+&60r"lB.b,3.<k~>endstream
 endobj
 12 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2547
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2425
 >>
 stream
-GauHLa`?F_'tii_hSJVfHUnJD=,frd6qJA^P"_UJkFbHS-j%p#:`(`]bMhs"4!28?[D<>Gh&RXk"VgL4Z8/bX8I#0`eR'sV3cXERbTtX]G=?,YgF%27'DLG2"*8m%J']4aW+Y+n(ZTktYo,=e#<0TN0tPAL9^W"N-;VEUNd8XIBp_CXF746foStKF!c$PYUX<^p^JTo<Gd0%X</'rOl'$NYq1J%>d'5!`:<8Ph+Z%OsRXFj?'Zn:W^X>aN1)#%`T^QHX#^f:Mp1;aNQ/[is7&3bq80u)a80gBqTu_4\VM-+MP\r$f7%#TIE?!$bESS=&<#!neAKmEN3kHW)@$KhG791ZhbH%$F5?WTq.AVc@.Q$*S'HW#t6+J@do)[]ti;Z`3NH*Qt*TD8CG(r=X_t\p8&CX>7P4#^Z<k_6Pr>=RAeDb%#cfn[]14RO&F?+IjD)t$17l=g`R:ABn3PDS1%^Kh`EdCPN8A<6NE[3PY=CsfD.$\/A8YJ'[[-CeEN_BM>8=;3*'m*/(=Z$kbN=:kSii#.DGH_UN7:Z>VD$ULea\,e+EjobOGhn_Ur7=SK?I^T:5is7&!@k`r\^Cj!"V/o9nDQR9:J)@Q`&F=GY'r?ZX[]@kdFaOke?*F?kjcE#Y?^+U]Ht`T7SNY%/S0f8k*VN!Gd8;NV+pA"%F6gM^T7gVGN<RiciIlA:b&n5l5bmYRYlJBiHdE6K%&ADbirX,0(&G^;ir>aY&kF\FBhcCcVd02G\iRKXd#`V.??@8SYb^O/;m2I%BLQ/n&K<P8)oH2$2s/2EpT)_G!`j.Ie:/+6l9O]Xs3g0@`PW.&d;>GBu=/YdQiqfD!]b9'nmG:p3InB@u?oa#tlHFln$UWTk(Uf[#U1,Or'c\5(H,(-2$/FZ0#RM((Ds#Dq`8o^r6,KfG?LX,mYo^[s!cPDml<T<=F"0Mg:f+T$;$PkSV8?j?uJALm"r$-FT:<PS#U\PE1qqfeHX,0a5nbAQ&$gCdH8*]hD$i4i@%F`j'^EiBTsH2K?kZGK5=SXmTjf%iG<5TPKRBr=Qj/%BQ<g?AI+15;6ekIZRNQa#("/m!aR2>.uu"@I3-)A[X.7;+"JLO)"@K`%[sP4)ln2&GD&X-eIe*gD(1;UYRTter'+\p%^7Foe6%uRT>>OlN.HYG<kTN=uo5C3XKig_e)5<X$UC\M(\!2oSb4PK$%[lNX*d[p<KWq"1aH7MBL`0@YVR50crdFb,b<oQ9@C$cfc%q!F,3"ld>CL:DHeR_0IBUn;uNfT`F12MNiB`1VZWlqj^QL,+cU1@8CTV%fg\UZ^89'%2VS!_Tc^Aik:/j>!oaoL[X0#=(O#=oNUPbgLSd%c/sCX>XjG4<&&0pD]6D2R%W@B)T`K4hlF]eM-O/1)X?Cg!D[=rhc0\-Hr,sR&-mKmE1JoMT/Oq1cLipFb69R[Pqln[^a1.'Q-C:m\P!?*,1_:4\-8hOKS9CdR;\hlQ/4)]"%Kuo.ti7nN35+fpkbM3Qi>_NfjC(_ZN"'>TYieMEN6]6#r\?T!]?/t4`jF"74.(f+\u*:Xs0"M@ffS1fTq<E)8[N)?^W"]oUS$bAXr#i4KRMfilq5l=Re9^b:A@L2I0"[D&\mGq?qW[Q;!WHf#TNV&9OF3WlcB%>s9q&@*]NQ`7$#[l;hm9g"U8^'h&JHelC+HWbsdi%'8=*B]%9"#0(%4mJlJl-XWaWe&d3EY86QZeSKR)G")?Slb?$*>F0Tj?U._lrOq8COE>MKAfM!M/=:.doN:H@fZ3In_/cS=?D0D$jgCid#b0pm(TVhK4GX8Ja1eWqoD2tKo,=WS/N800GAn.)s2Zn4C7IthOkIo!dt33G)PZSeH7Aq9+^&AF4+]"_N3-^J4)S-8i%Q0p4LQ5_,F5tD#KXI"mL[$L3G(VMg6@m_5&UI:<S(^]]MN7#7aW:d?OkfY^?8;A$E&O9)+J]1]#4C^Y':oUO]LLm.gl(p*pY%)!hdlP6+X33LZC6^S%(b8F<.EV!eCYZ"!$PJBWeu)qp9uHT([)H_7DY2A,e>9f&fN<co-#/bo3gtW)KWsZ:c7E*H(7^P7q[`H!4jp8ugX7YV86d)##WJ*J<n$eX,k8QY$mM.^t'W1_aO!1j?u;EeU84n(M>&`SCngnAG4fFdibnVR$\(bAT%`T:Sep3p.c10qBt[!$(1f1!NL1$;+Pk;=.9kTr*&+dnK\.ALA"^9P7RZD$W$q]8q8i0_\JSOe\M]J!+b]<^>4Y[5Y3a"^rc3!-CuMN&A'Y6LAQ)r5Y[h:[dL7N4_(f]],f2YKY_mb)SBnZIcMe[3heY*8@#j?#j,=/DTLC[/R^S-uJa"0C+*nGe7a8QX0(kU0R7,J).WpAZ/jJlFO@g^eL$*:^&Jib#jBQ]_Pf:p[hukVkOa0XBIlP+G;85k?)ua`TsL(h"d')jc4Cro?dlBqekF<%L0-//:7=SH^<I71^;`cp4#UmK;RM^Y()4>jJFrH@D=?P[G(A2PMG0#ll:ZP32fh%POHpMX)oVN@-q7maS*9[CViLQ.4NG-Q#>mUlp("Y$p+.oNO<s.~>endstream
+Gatm<>C5'p&q/*0W/&TEc445-DC0WQ"FKsqfECt]oAGs)C8>0/h3r3fL]-mEe[ckb=>OG"a-_e7<H[TVW@AnOif@Rk]bo]!"tm)"E*V&^_!-(>YdoJ@k1q-JSDq\"(IkQ[(ZTjeFnrIeKb'Xi*/EsdB6<BsNa)G5!F.`HUCf'GV\#dif9/^d_lplM/BV'EP_>T>0n3*td<pJhs'YFOZMbMfT%i]DF8NA_:\f&',53Rr5?2\9naE]n?='e;kP4oh@O>6n@kQ4W]>LmpL>Da/iHihY+qj,@*\M=egS*:9/@C@\)Y2+Zi0MJmQPoelU!]"MR/k0n,U_(ONAE4&R"l^Ra>9<@7bbh%P5k4H$M\i5AN&A3qsOiTL7Xl6Z]k]M7bdl_ih"@I(UjZ4@>s+l@1-,"RoZ)0M+Dk:,WC4(IrEgS?BH`k5B+Z6DZAc&]oII)Nkos:I"5'S,BqKV_oog@K>b[u(u;JkYAB0@ec#/W]q4-=9sA0C/SD-[lu"k"MIS@*rF=m$b.*XNKJi`dA'MD;(lTtDcd&j')`XC^di75gNGgUsCJBa>M0emQ%tBF7^Ct[TRN(3qmC(qoAgi!1egds>1K8%W"^Jo$1F^nCL35eh,/qJ8CZbcee/mDJ4+IRf*SP#n:pA_XnQ;X#%']]Shim$1a)E!=lFtQp>L%U]qckLP(_3F!W%&KhdKct3W_MS*"%]s=9&[#\=<mr>M?_;RMBH=>2caenbX8K$p+i4t0?AH=j9+b5##mpGP(<3,8]4MS.gD.h3^8GM(([VE`B6q-12R`l6+;%b)P8etq5&,uH!;LS#EVV((AQUVJg\YJ!43OLI$nT86`OO:5ApS6r!8mWWE,.d(k>5g[ai]u$BP3<kN3HQ)NQ5X1OFog^+c.a373^L:Ejqc&0jqJP'Opj.iJh_6.&XM_<I"MD[*,qm;tks6%8m(VZNhN=:BaKj*j'iD>]$J6p(d@4Fk5S"aR>uiB]jW5,AO"WV,gOi>('KE5<*QPBe$Df:'.<_=Op_=*Wh7P\#&,US;cb/AlpLGY1U*rUPS^7;In$p&@_s`:Zcj`)m3P'naBa3]b'(C"+bPD?g&G\+8]PATOEfeY)fcQ#4dB5kr&!NHnC4733)5ZX\<1Kq#^n9<j+@/Z18@D3AQH2eSY=gV&ph;J/'9-:u8oCq_&"0;S#=!%6fN?A[PpQ?\mSHt"@'cer+79T&kV@NHZBj4]/1BnEuVEfLiY[:J(Ll[#kd,%art?WK1g>LF=^58CUmq64$8nl"rcM'm9[gC)X*@8[M/+7YaC`3@TTXg0(f"#CB70YAV)`=B)&3U$TF5T]<o30!4f7Ck]LT_T8"3]Qhh?5qG;i%*%S.p6!1/>a)b:j7L5-,"91FL1<8GEWfd(,L?./18nO!H0?TaeBC9rnq_Qh5&r=.Tq]i@+l"973#h!oB7EPU-M`GK^D]1DACVY-`B._X\t5T/sgCD@u/:%[ICJX[AoTWY#@`^'J,Q)GY:'b$;=iEi6=Wm?p$L2+Tl^=BuIn,T8<gGZP8$%6:rZjNA[7q<]JK$].79R;,n1Yhd_#nh`W#LjQS%:Pj1j&EZ;;D_2.Tf$5I$+.6?%O8':PI?"PZ'a-Z.#;,fg/W6IKlkAMpI'tPMD'!G"Eb'uk?`o2s'AtLY*e8sC?`AY'QWo3iK]D)iI(3krsr7ST6EpIc^)3W/T?K+DAjl1W"[(m1A]:c">DQ43h>4@!R30Fj-5>MHB,r@:uH+f`P&(kiu)"%gi<K_6pS@fqegqa%D8@?ch96Tjb.HXm3d9iu,DZAlrn\nO(St4TYOXQp]Fqj:KrBb_UP[Q^ED"2\\b<:\=XNaHS1g?bkLq<Is$QjS!jf:oULJK%%XSb5YJ6X34k(<J`\Y3^R*U`sU#_Ukn'8B^JDX5]Glk)r6#8_+[('YHdan?od7%X_iST]rq<M'B&On'P*KKQXV&hYLf2\Q-?(i#f^iYH(A\!SB`ldJb^Bo_jJD4:rP"RBNq+tDD<<4\j6f'0G#-cYZ*@):,<m;9/nN6Wa1,XZ%f\6\f;I!S/r8o,`WJm5M1e@R<U=GD@ZKNPTUY'kTGC7Z;`\\8d1@&cnnQ-AYj4rp/,Sj:'f)hckZ%A5Dm*uWP+$)KhOh5f+n)mSV=B?hsV7#(e<QEtK4%`M(@2RRQoc!j`HJrd.r5'8Wn^/iOfagPS)kbY5e]*aGT'$K$kOW%uRHsE^Y@!Rt<gP]ou7Z=/1,'Yp2(qL\\m&o:0b9aB&"k]n7,3KAa69RD99P.#KpPL;kA%bokmtOJQ%Tp/`oBE=[fBD\5<El\94^ZdL-Y(8"Kp1+I]VVbM5re[?da_.HI:t(Bj!c:["`rpNR_NfiD7uVr_VVNQgm:+3JVF'f<F`p.8l"d6b<"\N[fB\5ps%&@hkJbG8,723`\PP6kN_/L;scDaYD[Yah4ID]Ek)~>endstream
+endobj
+13 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1951
+>>
+stream
+Gatm;b?!Xm&Dcpm[7KGq`!BLpiNNs#0hQ8$Cs>WhC`99i271jOWF^f8o'Nt>@@I;XS2190@+!<#>PD0`RUkI-XT!q\d<Ru)(JSX*'J-39[b;FSBc%h;4_R$]m+TtVpTYQFQ:(=`^-'3VooeGd3@tT$qC&s:WbDr(]P7(c2!,CXmGB>PH(e-a4H*2N1._ft9FI+$(h<q9#T]+0fl=qt+h?:1:jKq+O:r"C<>>)5A5_X3#4]Z!KS$*FSllsP;/f%A7lp;)DEnN[\Hn*L_Hs[hoq=u5ahL\N8hH&2c0fkYAAn(Pemu>&j.S*V=7K8]4Ng10Ys$Vge.bqnS%H-&YD7Y`?hf#0?Ea$OkSa0Q6I/SL?``/ggn[949?E6)4S)*-_T8QE3R9GYT^qu6<"Ho>XcggZas>F?6Fo0fRK*LOcHQs_*"sKU1&q@&NCT*Z18_sVMT8'TjG]mbcNR(qMCrqb+FolXP,'q-eZi?L[))jarVML/+a5j!MatDR1O,FV6L)%4o:/c!mfd<h:F:Co8V=`^9IebX9&Ks$9Y$s(Q"J"g2SL]5a/kMEs.2GQ_'CZB9lQ=W1X%j8nGo(0SsGmM[f%_r&L9%><lOr]d:umfY(>ToKQCnq*4P<]*7-Qi:8cpGQf$[FM(LTFc<B/('op,W]=d\tG>*YJ1q;=RAES&]kO*<BoJ0NDFibrf/WRZ`>6N.uNCfBf$P@C,0s:b1j#B1oQ);1!d'ZsbSn:/`-ADe(*l\7*ea&&Yag)8W[Fai,ZaP2s[;&$FD1:X%'@!Pp/**]6LTZ+^):Jh2_00,^r\V=FIn4(8/k7qFiY1qE`=+k*YalTAVIP6jmYEW\E='T":h7">_(V'4k_cG7*>WVXn)gRR+Wt,H=k62OJ90L:h!?k!/BWQ'k`7KNW5mp)[QS326q(<8n&<B4^+VsJ's[us$Fo/"XO>-00HlYY.<L2o#9eeQ')CoGn/=.XV[]*=]]g<Eo,2oqE1Rr@@7cEZ`,jsI&Bm)kg`-g#&`/o2!jj`bd,:.^#qI6o[SZG3@&p:$_-jk"3?Q>+Wf17Oi-q(QaSi$\&\aCtGG)g"%Mk"VL+hW`-f+j+k):t3IA8u<+^*+"R0cPk5V4A4>bT`f]IZgtl<]t`4NZ):J(q[1qt`B08MW.LqR*6mCQFti?2@LOD9rHIB'oe!p?1%&caK<c<>JS[8(Bor:/S<&*sFW'-'J,,0X^ltosXpg&8Qm)K\WF15e>SADU[n>9!%DT(G>+m7j<-5-/i0:Ii;Ss1`j5\iG8uhp=a6Tf@R`md>rte*Q/""Jq83=EO7q*lVNRCY#@^)$^Knr=m#8>ZTmqb)B!g,qNEpQlZlj_BQEOhZG[rM2<]B%eiIZ]iQ[E5XLsgmLf'Bi2T47AZK^jsEjqU$VhR_l$Qb`(!.1%OhO;)4^bR0O++8a*@Td2pjINMfkm"[F;Yb=T9CP]FDCS*&1>15(*Aj$q`:Cthk<:P&*mZ\R#E`p7A$M!Yp9UEJ-d$P2Z&4cFbK$*I]eFVUmgJ1O;d#]l*!m"`pbdf4'%mr3eNGI5/PF2,l_Jn\(20'm(/;Fj)FYrd$&ftYUR=Qc'U<)AK2knn>^qB?h.7@E+0\0-?f"sW$7G'?PG%/SB.kIr[aj%Wk>pou3o)[M[-R7c4#C.lFfX<,"]'ok_'dP<r9GksjG1(W^[URhkPOUgqTeq`X&],FbO:eNUq,opqGf;UNJS\!G3f\cK*Yb>j]Z`+@63t\1u7U8f1$=+G6#$DILr.lY?u;I[*V-L+_'QcFr.=`'fZ'^#n<86i4Q"uO1MXT7=h+?QQ`S8R!,+Rb<>=:2>mpZ?>Ia<j6)`q"JFASR_&X`FOq0j#>M7;p"O7q5.]r,"kp-;DqO>@X%'Igk%gUF'l!uc`G6gC[AbE%FA:<0n/Dnc4KZ,=]7S0=U[r54e'i3l)C9#m;%\`Qis(>&G!#dk#QFh,767@~>endstream
 endobj
 xref
-0 13
+0 14
 0000000000 65535 f 
 0000000061 00000 n 
-0000000122 00000 n 
-0000000229 00000 n 
-0000000341 00000 n 
-0000000418 00000 n 
-0000000533 00000 n 
-0000000728 00000 n 
-0000000923 00000 n 
-0000000992 00000 n 
-0000001272 00000 n 
-0000001338 00000 n 
-0000005085 00000 n 
+0000000112 00000 n 
+0000000219 00000 n 
+0000000331 00000 n 
+0000000408 00000 n 
+0000000603 00000 n 
+0000000798 00000 n 
+0000000993 00000 n 
+0000001062 00000 n 
+0000001342 00000 n 
+0000001414 00000 n 
+0000003763 00000 n 
+0000006280 00000 n 
 trailer
 <<
 /ID 
-[<0f1b45b26b27e12b6dc99530a9b20f5e><0f1b45b26b27e12b6dc99530a9b20f5e>]
+[<f35470bb027a71a4247559069856eafa><f35470bb027a71a4247559069856eafa>]
 % ReportLab generated PDF document -- digest (opensource)
 
 /Info 9 0 R
 /Root 8 0 R
-/Size 13
+/Size 14
 >>
 startxref
-7724
+8323
 %%EOF

--- a/scripts/build-resume.py
+++ b/scripts/build-resume.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""
+Resume PDF generator from markdown source.
+Converts a resume markdown file to a professional PDF using ReportLab.
+
+Usage:
+    python3 scripts/build-resume.py <resume.md> <out.pdf>
+
+Example:
+    python3 scripts/build-resume.py ../../../docs/40-personal/portfolio/_portfolio-root/nathan-walker-resume-se-leadership.md public/resume.pdf
+"""
+
+import sys
+import re
+from pathlib import Path
+from reportlab.lib.pagesizes import letter
+from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
+from reportlab.lib.units import inch
+from reportlab.platypus import SimpleDocTemplate, Paragraph, Spacer, Table, TableStyle, PageBreak
+from reportlab.lib import colors
+from reportlab.lib.enums import TA_LEFT, TA_CENTER, TA_JUSTIFY
+from reportlab.pdfgen import canvas
+
+
+def parse_markdown(md_text):
+    """
+    Parse markdown resume structure.
+    Returns a list of (type, content) tuples.
+    Types: 'h1', 'h2', 'h3', 'para', 'bullet', 'hr', 'table'
+    """
+    lines = md_text.split('\n')
+    elements = []
+    i = 0
+
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.strip()
+
+        # Skip empty lines (except after elements that need spacing)
+        if not stripped:
+            i += 1
+            continue
+
+        # H1
+        if stripped.startswith('# '):
+            elements.append(('h1', stripped[2:].strip()))
+            i += 1
+        # H2
+        elif stripped.startswith('## '):
+            elements.append(('h2', stripped[3:].strip()))
+            i += 1
+        # H3
+        elif stripped.startswith('### '):
+            elements.append(('h3', stripped[4:].strip()))
+            i += 1
+        # Horizontal rule
+        elif stripped.startswith('---'):
+            elements.append(('hr', None))
+            i += 1
+        # Table (markdown table)
+        elif '|' in stripped:
+            # Collect table lines
+            table_lines = [stripped]
+            i += 1
+            while i < len(lines) and '|' in lines[i].strip():
+                table_lines.append(lines[i].strip())
+                i += 1
+            if len(table_lines) > 1:
+                elements.append(('table', table_lines))
+        # Bullet (starts with -)
+        elif stripped.startswith('- '):
+            elements.append(('bullet', stripped[2:].strip()))
+            i += 1
+        # Paragraph
+        else:
+            # Accumulate multi-line paragraphs
+            para_lines = [stripped]
+            i += 1
+            while i < len(lines):
+                next_line = lines[i].strip()
+                if not next_line:
+                    break
+                if next_line.startswith(('#', '|', '-', '---')):
+                    break
+                para_lines.append(next_line)
+                i += 1
+            if para_lines:
+                elements.append(('para', ' '.join(para_lines)))
+
+    return elements
+
+
+def format_text(text):
+    """
+    Convert markdown inline formatting to ReportLab compatible text.
+    **bold** -> <b>bold</b>
+    Preserves other text as-is.
+    """
+    # Bold: **text** -> <b>text</b>
+    text = re.sub(r'\*\*([^*]+)\*\*', r'<b>\1</b>', text)
+    return text
+
+
+def parse_table(table_lines):
+    """
+    Parse markdown table into rows.
+    Returns list of rows, where each row is a list of cell texts.
+    """
+    rows = []
+    for line in table_lines:
+        cells = [cell.strip() for cell in line.split('|') if cell.strip()]
+        if cells:
+            rows.append(cells)
+
+    # Remove header separator row (all dashes)
+    filtered_rows = []
+    for row in rows:
+        if not all(c.replace('-', '').replace(':', '') == '' for c in row):
+            filtered_rows.append(row)
+
+    return filtered_rows
+
+
+def build_pdf(md_path, pdf_path):
+    """Build resume PDF from markdown source."""
+
+    md_text = Path(md_path).read_text(encoding='utf-8')
+    elements_list = parse_markdown(md_text)
+
+    # Set up PDF
+    pdf_path = Path(pdf_path)
+    pdf_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Margins
+    margin = 0.75 * inch
+    page_width, page_height = letter
+    available_width = page_width - 2 * margin
+
+    # Create document with custom page size accounting for margins
+    doc = SimpleDocTemplate(
+        str(pdf_path),
+        pagesize=letter,
+        rightMargin=margin,
+        leftMargin=margin,
+        topMargin=margin,
+        bottomMargin=margin,
+    )
+
+    # Styles
+    styles = getSampleStyleSheet()
+
+    name_style = ParagraphStyle(
+        'NameStyle',
+        parent=styles['Heading1'],
+        fontSize=20,
+        textColor=colors.HexColor('#1a1a1a'),
+        spaceAfter=6,
+        alignment=TA_CENTER,
+        fontName='Helvetica-Bold',
+    )
+
+    h2_style = ParagraphStyle(
+        'H2Style',
+        parent=styles['Heading2'],
+        fontSize=12,
+        textColor=colors.HexColor('#2c2c2c'),
+        spaceAfter=8,
+        spaceBefore=10,
+        fontName='Helvetica-Bold',
+        borderPadding=0,
+    )
+
+    h3_style = ParagraphStyle(
+        'H3Style',
+        parent=styles['Heading3'],
+        fontSize=11,
+        textColor=colors.HexColor('#2c2c2c'),
+        spaceAfter=4,
+        spaceBefore=6,
+        fontName='Helvetica-Bold',
+    )
+
+    body_style = ParagraphStyle(
+        'BodyStyle',
+        parent=styles['Normal'],
+        fontSize=10,
+        textColor=colors.HexColor('#333333'),
+        spaceAfter=6,
+        alignment=TA_JUSTIFY,
+        leading=12,
+    )
+
+    bullet_style = ParagraphStyle(
+        'BulletStyle',
+        parent=styles['Normal'],
+        fontSize=10,
+        textColor=colors.HexColor('#333333'),
+        spaceAfter=4,
+        leftIndent=18,
+        leading=11,
+    )
+
+    contact_style = ParagraphStyle(
+        'ContactStyle',
+        parent=styles['Normal'],
+        fontSize=9,
+        textColor=colors.HexColor('#555555'),
+        spaceAfter=8,
+        alignment=TA_CENTER,
+        leading=10,
+    )
+
+    # Build story
+    story = []
+
+    for elem_type, content in elements_list:
+        if elem_type == 'h1':
+            story.append(Paragraph(format_text(content), name_style))
+
+        elif elem_type == 'para':
+            # Check if it's a contact info paragraph (contains @ or phone)
+            if '@' in content or '•' in content:
+                story.append(Paragraph(format_text(content), contact_style))
+            else:
+                story.append(Paragraph(format_text(content), body_style))
+
+        elif elem_type == 'h2':
+            story.append(Spacer(1, 0.08 * inch))
+            story.append(Paragraph(format_text(content), h2_style))
+
+        elif elem_type == 'h3':
+            story.append(Paragraph(format_text(content), h3_style))
+
+        elif elem_type == 'bullet':
+            # Format bullet with a dash
+            bullet_text = '• ' + format_text(content)
+            story.append(Paragraph(bullet_text, bullet_style))
+
+        elif elem_type == 'hr':
+            story.append(Spacer(1, 0.12 * inch))
+
+        elif elem_type == 'table':
+            rows = parse_table(content)
+            if rows:
+                # Flatten all table cells to bullets, row by row, left then right,
+                # skipping empty cells. Avoids ReportLab Table text-overflow issues.
+                for row in rows:
+                    for cell in row:
+                        if cell.strip():
+                            bullet_text = '• ' + format_text(cell.strip())
+                            story.append(Paragraph(bullet_text, bullet_style))
+                story.append(Spacer(1, 0.06 * inch))
+
+    # Build PDF
+    doc.build(story)
+    return pdf_path
+
+
+if __name__ == '__main__':
+    if len(sys.argv) < 3:
+        print(__doc__)
+        sys.exit(1)
+
+    md_file = sys.argv[1]
+    pdf_file = sys.argv[2]
+
+    try:
+        result_path = build_pdf(md_file, pdf_file)
+        print(f"✓ Generated: {result_path}")
+    except Exception as e:
+        print(f"✗ Error: {e}", file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
Task 18: resume.pdf regenerated from the corrected markdown source via a new committed generator (scripts/build-resume.py — usage: `python3 scripts/build-resume.py <resume.md> <out.pdf>`). Verified: 38% ×3, no 76%, renders clean.

Note for Nathan: the SE Leadership .docx never contained 76% — it says "near-perfect POC-to-deal conversion" in two places, which now overstates against the 38% canon. Your call on rewording the docx; left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)