### PR TITLE
fix: owner corrections — hero emphasis, doctrine page as article index

### DIFF
--- a/src/app/__tests__/page.test.tsx
+++ b/src/app/__tests__/page.test.tsx
@@ -9,7 +9,7 @@ describe('Homepage', () => {
     expect(screen.getByText('AI Governance & Enterprise Platforms')).toBeTruthy()
     expect(screen.getByText(/AI eliminated the cost of building/)).toBeTruthy()
     expect(container).toHaveTextContent(/It did not eliminate the cost of being wrong/)
-    expect(container.querySelector('h1 em, p em')).toBeNull() // no italic drama
+    expect(container.querySelector('p em')?.textContent).toMatch(/wrong/) // owner-canonical emphasis
   })
 
   it('renders What AI Did Not Collapse with the scar closing line', () => {

--- a/src/app/frameworks/architecting-certainty/page.tsx
+++ b/src/app/frameworks/architecting-certainty/page.tsx
@@ -6,60 +6,26 @@ import { buildCollectionPageSchema, createGraph } from '@/lib/seo/schema'
 export const metadata: Metadata = {
   title: 'Architecting Certainty | Nathan Walker',
   description:
-    'An eight-pillar methodology for high-stakes technology demonstrations: earning the right to demo, narrative structure, value engineering, and execution discipline.',
+    'Architecting Certainty: The Definitive Guide to the High-Stakes Technology Demonstration — an eight-pillar methodology for proof-of-value engagements.',
   alternates: {
     canonical: '/frameworks/architecting-certainty',
   },
 }
 
-const pillars = [
-  {
-    name: 'The Power of Storytelling',
-    definition:
-      'Humans absorb knowledge through narrative. Every feature becomes a story of transformation: a relatable persona in their ordinary world, their pain as the call to adventure, your platform as the mentor, and measurable transformation as the reward. Technology must feel like a "hard magic system"—governed by understandable rules and defined limitations that build trust.',
-  },
-  {
-    name: 'The Experience',
-    definition:
-      'First impressions are irreversible. Voice quality, perceived latency, and initial responsiveness are the difference between perceived intelligence and skepticism. Disarm the IVR shadow your customers carry from years of poor automation. Personalization in their own terminology, elegant simplicity over engineering theater—these elements compound trust faster than feature lists.',
-  },
-  {
-    name: 'The Completeness',
-    definition:
-      'Superficial demonstrations sow doubt about production-readiness. You must show feature depth, populated realistic environments, multiple channels, and integrated technology partners. The absence of evidence that you can handle their operational complexity signals that your platform is a concept, not a solution ready to inherit their workload.',
-  },
-  {
-    name: 'The Fidelity',
-    definition:
-      'Move beyond the happy path. Demonstrate chained functions across data sources, ambiguous requests that require disambiguation, and proactive intelligence that anticipates client need. What impresses internal teams is not what closes deals—clients value robustness under constraint and handling of the messy problems they actually face.',
-  },
-  {
-    name: 'Demonstrable Value',
-    definition:
-      'Customers do not buy features; they buy financial outcomes. You must speak the three languages of the C-suite: cost reduction for the CFO, revenue creation for the CEO, and risk mitigation for the board. If your demonstration cannot connect to the P&L, it failed. Value engineering is the discipline of designing your solution and narrative to deliver maximum financial impact.',
-  },
-  {
-    name: 'Objection Handling & Preemption',
-    definition:
-      'Maintain a drilled library of responses to common objections. Weave answers directly into your narrative before they surface—preemption demonstrates you have thought through their constraints. Master the Parking Lot: when a prospect derails into deep technical weeds, acknowledge the question, record it, and propose return after you establish the business case. Grace under fire is not optional—when the demo breaks, you are demonstrating your professionalism, not just your software.',
-  },
-  {
-    name: 'Strategic Demo Execution & Call to Action',
-    definition:
-      'Treat the demonstration as a orchestrated production with clear roles and objectives. The Situation Slide ("What We\'ve Learned About You") is your foundation—summarize your understanding of their business, challenges, and goals, then validate it by asking "Did we get this right?" This single step proves you listened. Close with a Mutual Closure Plan: reframe the call to action from an ask into a proposed collaborative path forward, and secure verbal commitment before the meeting ends.',
-  },
-  {
-    name: "The Presenter's Polish",
-    definition:
-      'Professional discipline in audio quality, lighting, and digital hygiene is not optional—it is the operating system for credibility. In physical rooms, vocal projection, eye contact, and a clean desk are your command of the environment. Find Your Guitar: the element that transforms a sterile meeting into a conversation between people who share a passion. A genuine human connection built on authentic interest is your greatest competitive differentiator.',
-  },
-]
+// Canonical publication. Swap to the Substack/Medium URL when that edition ships.
+const articleUrl =
+  'https://www.linkedin.com/pulse/architecting-certainty-definitive-guide-high-stakes-nathan-walker-n01bc/'
 
-const demoFactory = {
-  name: 'The Demo Factory',
-  definition:
-    'Artisanal craft does not scale. Demo assets must be treated as source code: versioned, deployed through continuous integration pipelines, regression-tested in automated environments, and gated through formal approval. Your demonstration environments must run with the same rigor as your production systems. Automated testing and health checks prevent issues before they reach a live presentation. This is how you deliver excellence reliably.',
-}
+const pillars = [
+  'The Power of Storytelling',
+  'The Experience',
+  'The Completeness',
+  'The Fidelity',
+  'Demonstrable Value',
+  'Objection Handling & Preemption',
+  'Strategic Demo Execution & Call to Action',
+  "The Presenter's Polish",
+]
 
 export default function ArchitectingCertaintyPage() {
   const schema = createGraph([
@@ -67,7 +33,7 @@ export default function ArchitectingCertaintyPage() {
       path: '/frameworks/architecting-certainty',
       name: 'Architecting Certainty',
       description:
-        'An eight-pillar methodology for high-stakes technology demonstrations: earning the right to demo, narrative structure, value engineering, and execution discipline.',
+        'Architecting Certainty: The Definitive Guide to the High-Stakes Technology Demonstration — an eight-pillar methodology for proof-of-value engagements.',
     }),
   ])
 
@@ -79,148 +45,41 @@ export default function ArchitectingCertaintyPage() {
           Frameworks / Architecting Certainty
         </p>
         <h1 className="text-[var(--text-primary)] text-3xl md:text-5xl font-light tracking-tight leading-tight mb-8">
-          Certainty is architected, not performed.
+          Architecting Certainty
         </h1>
         <p className="text-[var(--text-secondary)] text-lg md:text-xl leading-relaxed mb-4">
-          A technology demonstration is the single most critical moment to forge connection, prove
-          understanding, and secure client confidence. It is not a showcase of features. It is a
-          structured methodology for moving a prospect along the Certainty Spectrum—from
-          uncertainty, skepticism, and perceived risk toward absolute confidence—not just in your
-          product, but in your ability to solve their specific problem.
+          The Definitive Guide to the High-Stakes Technology Demonstration — a structured
+          methodology for moving a prospect along the Certainty Spectrum: from uncertainty,
+          skepticism, and perceived risk to confidence that you can solve their problem.
         </p>
-        <p className="text-[var(--text-secondary)] text-lg md:text-xl leading-relaxed mb-16">
-          This framework is forged across hundreds of enterprise technology demonstrations,
-          synthesizing Solution Selling, Value-Based Selling, and narrative craft. It exists
-          because every organization deserves a documented methodology for excellence in this role.
+        <p className="text-[var(--text-secondary)] text-lg md:text-xl leading-relaxed mb-12">
+          Forged across hundreds of enterprise engagements and a 38% POC-to-deal conversion
+          record. The full guide is published as a standalone article; this page is its index.
         </p>
+
+        <a
+          href={articleUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-block text-[var(--primary)] text-lg font-medium hover:underline underline-offset-4 mb-16"
+        >
+          Read the full guide →
+        </a>
 
         <section className="border-t border-[var(--edge)] pt-12 mb-16">
           <h2 className="text-[var(--text-primary)] text-2xl font-semibold mb-6">
-            Earning the Right to Demo
-          </h2>
-          <p className="text-[var(--text-secondary)] text-base leading-relaxed mb-6">
-            The most critical battle is won or lost before a single slide is shown. Demonstrating
-            too early—without deep understanding of the prospect&apos;s business, pain points, desired
-            outcomes, and technical environment—teaches them you do not understand their world.
-            They will conclude you chose the wrong use case, not that your platform cannot solve
-            their problems.
-          </p>
-          <p className="text-[var(--text-secondary)] text-base leading-relaxed mb-6">
-            Discovery is everything. You must build a comprehensive blueprint through these
-            investigations:
-          </p>
-          <ul className="text-[var(--text-secondary)] text-base leading-relaxed space-y-3 mb-6 ml-4">
-            <li>
-              <strong>Understanding Their Business:</strong> What are their core services, customer
-              base, and operational landscape? Where do they position themselves in the market?
-            </li>
-            <li>
-              <strong>Identifying Pain Points:</strong> Where are they experiencing inefficiencies,
-              high costs, or dissatisfaction? Dig into their metrics—long wait times, low FCR, high
-              AHT, repetitive manual tasks, lack of personalization.
-            </li>
-            <li>
-              <strong>Defining Key Use Cases:</strong> How could your solution directly and
-              surgically address these specific pain points? Map your capabilities to their stated
-              needs with precision.
-            </li>
-            <li>
-              <strong>Uncovering Desired Outcomes:</strong> What does success look like? A 20%
-              reduction in operational costs? A measurable improvement in customer satisfaction? You
-              must know their finish line.
-            </li>
-            <li>
-              <strong>Identifying the Technical Environment:</strong> What existing CRM, contact
-              center platforms, and backend systems must you integrate with? A solution without a
-              clear integration path is a science project.
-            </li>
-          </ul>
-          <p className="text-[var(--text-secondary)] text-base leading-relaxed mb-6">
-            When you have these answers, you can show one perfect first demo. One single,
-            precisely aimed use case that proves you listened, understand their business, their
-            pain, and exactly how to solve it. You only get one shot at this first meeting. Earn
-            the right to a deeper partnership through disciplined discovery.
-          </p>
-        </section>
-
-        <section className="border-t border-[var(--edge)] pt-12 mb-16">
-          <h2 className="text-[var(--text-primary)] text-2xl font-semibold mb-8">
             The Eight Pillars
           </h2>
-
-          <div className="space-y-12">
-            {pillars.map((pillar) => (
-              <article key={pillar.name} className="border-t border-[var(--edge)] pt-8">
-                <h3 className="text-[var(--text-primary)] text-xl font-semibold mb-4">
-                  {pillar.name}
-                </h3>
-                <p className="text-[var(--text-secondary)] text-base leading-relaxed">
-                  {pillar.definition}
-                </p>
-              </article>
+          <ol className="space-y-3 list-none">
+            {pillars.map((p, i) => (
+              <li key={p} className="text-[var(--text-secondary)] text-lg">
+                <span className="font-[family-name:var(--font-mono)] text-[var(--text-muted)] mr-3">
+                  {String(i + 1).padStart(2, '0')}
+                </span>
+                {p}
+              </li>
             ))}
-          </div>
-        </section>
-
-        <section className="border-t border-[var(--edge)] pt-12 mb-16">
-          <h2 className="text-[var(--text-primary)] text-2xl font-semibold mb-4">
-            {demoFactory.name}
-          </h2>
-          <p className="text-[var(--text-secondary)] text-base leading-relaxed">
-            {demoFactory.definition}
-          </p>
-          <p className="text-[var(--text-secondary)] text-base leading-relaxed mt-4">
-            Your demo environments must embed automated testing and health checks directly into
-            the development cycle. Every change triggers a regression suite. Continuous,
-            automated health checks on all demo environments are mandatory to prevent issues
-            before they reach a live presentation. Version control for everything—dialog flows,
-            knowledge content, configurations—ensures auditability and rapid recovery.
-          </p>
-          <p className="text-[var(--text-secondary)] text-base leading-relaxed mt-4">
-            Deployments to any environment (development, staging, production) should be
-            handled by an automated, script-based process. A central tracking system—governed by
-            core DevOps and Site Reliability principles—serves as the single source of truth.
-            Formal gating from stakeholder UAT to leadership approval ensures complete
-            transparency and control.
-          </p>
-        </section>
-
-        <section className="border-t border-[var(--edge)] pt-12 mb-16">
-          <h2 className="text-[var(--text-primary)] text-2xl font-semibold mb-4">
-            From Demonstration to Certainty
-          </h2>
-          <p className="text-[var(--text-secondary)] text-base leading-relaxed mb-4">
-            The entire methodology condenses into a single principle: Start with Why.
-          </p>
-          <p className="text-[var(--text-secondary)] text-base leading-relaxed mb-4">
-            A good demonstration does not begin with your product. It starts with the
-            client&apos;s reality. It asks:
-          </p>
-          <ul className="text-[var(--text-secondary)] text-base leading-relaxed space-y-3 mb-6 ml-4">
-            <li>
-              <strong>Why are we here?</strong> Because you have a problem, a pain point, a
-              strategic goal. Let&apos;s talk about that first.
-            </li>
-            <li>
-              <strong>How can we help?</strong> By understanding that &quot;why,&quot; we can now tell a
-              story of &quot;how&quot; a hero in your organization can overcome that challenge.
-            </li>
-            <li>
-              <strong>What do we do?</strong> The product, the features, the platform—that&apos;s
-              simply the &quot;what.&quot; It is the proof. It is the tangible evidence that makes the
-              &quot;how&quot; possible and the &quot;why&quot; solvable.
-            </li>
-          </ul>
-          <p className="text-[var(--text-secondary)] text-base leading-relaxed mb-4">
-            By mastering this philosophy, you move beyond simply demonstrating features and begin
-            architecting certainty. You prove not only that the solution can do what you claim,
-            but what it will do for them. You transform a technical presentation into a strategic
-            business conversation.
-          </p>
-          <p className="text-[var(--text-secondary)] text-base leading-relaxed">
-            This is the difference between a demo that is merely seen and a demo that closes
-            deals.
-          </p>
+          </ol>
         </section>
 
         <div className="flex gap-8">
@@ -228,13 +87,13 @@ export default function ArchitectingCertaintyPage() {
             href="/frameworks"
             className="text-[var(--primary)] text-base font-medium hover:underline underline-offset-4"
           >
-            &larr; All frameworks
+            ← All frameworks
           </Link>
           <Link
             href="/enterprise"
             className="text-[var(--primary)] text-base font-medium hover:underline underline-offset-4"
           >
-            Enterprise work &rarr;
+            Enterprise work →
           </Link>
         </div>
       </section>

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -14,7 +14,7 @@ export function Hero() {
               AI eliminated the cost of building.
             </p>
             <p className="text-[var(--text-primary)] text-xl md:text-2xl font-light leading-relaxed">
-              It did not eliminate the cost of being wrong.
+              It did not eliminate the cost of being <em>wrong.</em>
             </p>
           </div>
         </div>


### PR DESCRIPTION
Per Nathan 2026-06-12:
- Restore italics on "wrong" in the hero thesis (his intended emphasis; overrides v2.1 strategy delta #2 — strategy doc amended separately)
- /frameworks/architecting-certainty no longer paraphrases the article; it's an index: summary, Certainty Spectrum, eight pillar names, and a canonical link to the LinkedIn publication (swap to Substack/Medium when live)

🤖 Generated with [Claude Code](https://claude.com/claude-code)