### PR TITLE
fix(hero): scroll hint visibility + name-merge into sticky nav

### DIFF
--- a/src/components/layout/Nav.tsx
+++ b/src/components/layout/Nav.tsx
@@ -2,7 +2,8 @@
 
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
+import { useUIStore } from '@/stores/ui'
 
 const navLinks = [
   { label: 'Philosophy', href: '/philosophy' },
@@ -15,28 +16,24 @@ const navLinks = [
 export function Nav() {
   const pathname = usePathname()
   const [mobileOpen, setMobileOpen] = useState(false)
-  const [scrolled, setScrolled] = useState(false)
   const isHome = pathname === '/'
 
-  useEffect(() => {
-    if (!isHome) return
-    function onScroll() {
-      setScrolled(window.scrollY > 100)
-    }
-    onScroll()
-    window.addEventListener('scroll', onScroll, { passive: true })
-    return () => window.removeEventListener('scroll', onScroll)
-  }, [isHome])
-
-  const showName = !isHome || scrolled
+  // On the home page the name lives in the hero and merges into the bar on
+  // scroll (Hero drives heroHandoff 0→1). Everywhere else it's always present.
+  const heroHandoff = useUIStore((s) => s.heroHandoff)
+  const nameOpacity = isHome ? heroHandoff : 1
+  const nameHidden = nameOpacity < 0.05
 
   return (
     <nav className="fixed top-0 left-0 right-0 z-50 py-5 bg-[var(--background)]/80 backdrop-blur-xl border-b border-[var(--edge)]">
       <div className="max-w-[1200px] mx-auto px-8 flex items-center justify-between">
         <Link
           href="/"
-          className={`text-[var(--text-primary)] text-lg font-semibold tracking-tight transition-opacity duration-300 ${
-            showName ? 'opacity-100' : 'opacity-0'
+          aria-hidden={nameHidden}
+          tabIndex={nameHidden ? -1 : undefined}
+          style={{ opacity: nameOpacity }}
+          className={`text-[var(--text-primary)] text-lg font-semibold tracking-tight ${
+            nameHidden ? 'pointer-events-none' : ''
           }`}
         >
           Nathan Walker

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -1,9 +1,81 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { useUIStore } from '@/stores/ui'
+
 export function Hero() {
+  const nameRef = useRef<HTMLHeadingElement>(null)
+  const setHeroHandoff = useUIStore((s) => s.setHeroHandoff)
+  const [nameOpacity, setNameOpacity] = useState(1)
+  const [hintOpacity, setHintOpacity] = useState(0)
+
+  useEffect(() => {
+    const navEl = document.querySelector('nav')
+    const navH = navEl instanceof HTMLElement ? navEl.offsetHeight : 72
+    // The crossfade zone: as the hero name's top rises from just below the bar
+    // (start) to tucked under it (end), it hands off to the sticky nav name.
+    const start = navH + 64
+    const end = navH - 8
+
+    let hintReady = false
+    let frame = 0
+    let lastHandoff = -1
+
+    function measure() {
+      frame = 0
+      const scrollY = window.scrollY
+
+      const el = nameRef.current
+      if (el) {
+        const top = el.getBoundingClientRect().top
+        const raw = (start - top) / (start - end)
+        const p = Math.min(1, Math.max(0, raw))
+        const q = Math.round(p * 20) / 20 // quantize to 0.05 to limit re-renders
+        if (q !== lastHandoff) {
+          lastHandoff = q
+          setNameOpacity(1 - q)
+          setHeroHandoff(q)
+        }
+      }
+
+      // Gentle, capped hint that fades as soon as the visitor scrolls.
+      const base = Math.max(0, Math.min(1, 1 - scrollY / 100)) * 0.7
+      setHintOpacity(hintReady ? base : 0)
+    }
+
+    function onScroll() {
+      if (!frame) frame = requestAnimationFrame(measure)
+    }
+
+    measure() // initial sync (hint stays hidden until the delay below)
+    const revealTimer = setTimeout(() => {
+      hintReady = true
+      measure()
+    }, 1200)
+
+    window.addEventListener('scroll', onScroll, { passive: true })
+    window.addEventListener('resize', onScroll, { passive: true })
+    return () => {
+      clearTimeout(revealTimer)
+      if (frame) cancelAnimationFrame(frame)
+      window.removeEventListener('scroll', onScroll)
+      window.removeEventListener('resize', onScroll)
+      setHeroHandoff(0) // reset so non-home pages always show the nav name
+    }
+  }, [setHeroHandoff])
+
+  // 72px = the global body pt-[72px] that clears the fixed nav, so the hero
+  // fills exactly the area below it and the scroll hint lands on-screen.
   return (
-    <section className="min-h-screen flex items-center relative">
+    <section className="min-h-[calc(100dvh-72px)] flex items-center relative">
       <div className="max-w-[1200px] mx-auto px-8 w-full">
         <div className="max-w-[720px]">
-          <h1 className="text-[var(--text-primary)] text-4xl md:text-5xl font-light tracking-tight leading-tight mb-4">
+          <h1
+            ref={nameRef}
+            id="hero-name"
+            style={{ opacity: nameOpacity }}
+            className="text-[var(--text-primary)] text-4xl md:text-5xl font-light tracking-tight leading-tight mb-4 will-change-[opacity]"
+          >
             Nathan Walker
           </h1>
           <p className="text-[var(--text-secondary)] text-lg md:text-xl mb-16">
@@ -19,7 +91,11 @@ export function Hero() {
           </div>
         </div>
       </div>
-      <div className="absolute bottom-12 left-1/2 -translate-x-1/2 text-[var(--text-muted)] text-sm tracking-widest">
+      <div
+        aria-hidden="true"
+        style={{ opacity: hintOpacity }}
+        className="absolute bottom-8 left-1/2 -translate-x-1/2 text-[var(--text-muted)] text-sm tracking-widest transition-opacity duration-700 ease-out pointer-events-none"
+      >
         Scroll ↓
       </div>
     </section>

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -3,15 +3,20 @@ import { create } from 'zustand'
 interface UIState {
   navOpen: boolean
   activeModal: string | null
+  /** 0 = hero name sits in the thesis block, 1 = it has merged into the sticky nav bar. */
+  heroHandoff: number
   toggleNav: () => void
   openModal: (id: string) => void
   closeModal: () => void
+  setHeroHandoff: (value: number) => void
 }
 
 export const useUIStore = create<UIState>((set) => ({
   navOpen: false,
   activeModal: null,
+  heroHandoff: 0,
   toggleNav: () => set((s) => ({ navOpen: !s.navOpen })),
   openModal: (id) => set({ activeModal: id }),
   closeModal: () => set({ activeModal: null }),
+  setHeroHandoff: (value) => set({ heroHandoff: value }),
 }))


### PR DESCRIPTION
Two homepage polish fixes per Nathan:

**Scroll hint** — was hidden below the fold because the 100dvh hero starts beneath the global `body pt-[72px]` nav offset, pushing its bottom 72px off-screen. Now `min-h-[calc(100dvh-72px)]`, so the hint sits at the visible viewport bottom. Added a ~1.2s delayed fade-in and a fade-out on scroll so it hints without competing with the thesis.

**Name merge** — the hero name now crossfades into the nav bar as it scrolls up to meet it (driven by the name's measured position via a shared `heroHandoff` store value, 0→1), then stays sticky — replacing the abrupt `scrollY > 100` toggle. Verified in-browser: clean 0.45/0.55 handoff at the midpoint, fully merged by ~320px.

Note: `<em>wrong.</em>` emphasis preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)