### PR TITLE
fix(transition): eliminate page-navigation double-load (flash + refade)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -14,3 +14,24 @@ body {
   background: var(--primary);
   color: white;
 }
+
+/* Page transition: a one-shot fade that runs on mount of each keyed route.
+   Pure CSS so a re-render can't replay it (the cause of the old flash). */
+@keyframes page-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.page-fade-in {
+  animation: page-fade-in 0.3s ease-in-out both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .page-fade-in {
+    animation: none;
+  }
+}

--- a/src/components/layout/PageTransition.tsx
+++ b/src/components/layout/PageTransition.tsx
@@ -1,22 +1,18 @@
 'use client'
 
-import { motion, AnimatePresence } from 'framer-motion'
 import { usePathname } from 'next/navigation'
 
+// A pure-CSS fade keyed on the pathname: each navigation mounts a fresh element
+// whose keyframe runs exactly once (0 → 1). There's no animation-library
+// lifecycle, so the new page can't flash in, fade out, then fade back in (the
+// App Router exit-animation bug). A re-render of the same route keeps the same
+// element, so the animation never replays mid-stay.
 export function PageTransition({ children }: { children: React.ReactNode }) {
   const pathname = usePathname()
 
   return (
-    <AnimatePresence mode="wait" initial={false}>
-      <motion.div
-        key={pathname}
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        exit={{ opacity: 0 }}
-        transition={{ duration: 0.3, ease: 'easeInOut' }}
-      >
-        {children}
-      </motion.div>
-    </AnimatePresence>
+    <div key={pathname} className="page-fade-in">
+      {children}
+    </div>
   )
 }


### PR DESCRIPTION
**Bug:** navigating between pages, the new page's text appeared, disappeared, then faded in.

**Cause:** `PageTransition` used `AnimatePresence mode="wait"` with an `exit` animation. In the Next.js App Router, `children` is swapped to the new route synchronously on navigation, so the exiting `motion.div` played its fade-out on the *already-updated* content — new page shows at full opacity, fades to 0, then the entering div fades it back 0→1. Captured the exact opacity trace in-browser to confirm.

**Fix:** dropped Framer for this path; `PageTransition` is now a pathname-keyed `<div className="page-fade-in">` running a single CSS keyframe (0→1) on mount. A keyed element animates exactly once per navigation and a re-render can't replay it. Added a `prefers-reduced-motion` opt-out.

**Verified** in a production build (`next start`), both directions: clean monotonic 0→1, `maxDropAfterVisible: 0.000`, no flash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)